### PR TITLE
fix: add immediate retry abort for 429/503 status codes

### DIFF
--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -962,6 +962,17 @@ class RequestHandler {
 
                 lastError = errorPayload;
 
+                // Check if we should stop retrying immediately based on status code
+                if (
+                    this.config.immediateSwitchStatusCodes &&
+                    this.config.immediateSwitchStatusCodes.includes(errorPayload.status)
+                ) {
+                    this.logger.warn(
+                        `[Request] Critical error ${errorPayload.status} detected (${errorPayload.message}), aborting retries immediately.`
+                    );
+                    break;
+                }
+
                 // Log the warning for the current attempt
                 this.logger.warn(
                     `[Request] Attempt #${attempt}/${this.maxRetries} for request #${proxyRequest.request_id} failed: ${errorPayload.message}`


### PR DESCRIPTION
中文：优化了请求重试逻辑，遇到 429 等特定错误码时立即停止重试，以节省资源并加速账号切换。

English: Optimized the request retry logic to immediately halt retries upon encountering specific error codes (like 429) to save resources and accelerate account switching.
- fix #37 