### PR TITLE
feat: add Claude API compatible endpoint (/v1/messages)

### DIFF
--- a/src/core/ProxyServerSystem.js
+++ b/src/core/ProxyServerSystem.js
@@ -446,6 +446,11 @@ class ProxyServerSystem extends EventEmitter {
             this.requestHandler.processOpenAIRequest(req, res);
         });
 
+        // Claude API compatible endpoint
+        app.post("/v1/messages", (req, res) => {
+            this.requestHandler.processClaudeRequest(req, res);
+        });
+
         // VNC WebSocket downgrade / missing headers handler
         // If Nginx or another proxy strips "Upgrade: websocket" headers, the request appears as a normal GET.
         // We intercept it here to prevent it from falling through to the Gemini proxy.


### PR DESCRIPTION
## Summary

This PR adds support for Claude/Anthropic API format, allowing clients using Anthropic SDK to connect directly to this proxy.

## New Features

- **New endpoint**: `POST /v1/messages`
- **Request conversion**: Claude format → Gemini format
- **Response conversion**: Gemini format → Claude format (both stream and non-stream)
- **System prompt**: Support for Claude's separate `system` field
- **Tool use**: Support for `tool_use` and `tool_result` blocks
- **Thinking mode**: Support for thinking blocks
- **SSE events**: Proper Claude streaming format (`message_start`, `content_block_delta`, `message_stop`, etc.)

## Usage Example

```python
import anthropic

client = anthropic.Anthropic(
    api_key="your-api-key",
    base_url="http://localhost:7860"
)

# Non-streaming
message = client.messages.create(
    model="gemini-2.5-flash",
    max_tokens=1024,
    messages=[{"role": "user", "content": "Hello!"}]
)
print(message.content[0].text)

# Streaming
with client.messages.stream(
    model="gemini-2.5-flash",
    max_tokens=1024,
    messages=[{"role": "user", "content": "Hello!"}]
) as stream:
    for text in stream.text_stream:
        print(text, end="", flush=True)
```

## Files Changed

- `src/core/FormatConverter.js` - Added Claude ↔ Gemini conversion methods
- `src/core/RequestHandler.js` - Added `processClaudeRequest()` handler
- `src/core/ProxyServerSystem.js` - Added `/v1/messages` route

## Testing

All tests passed:
- ✅ Non-stream request
- ✅ Request with system prompt
- ✅ Multi-turn conversation
- ✅ Stream request with proper SSE events