### PR TITLE
fix: prevent internal traffic proxying

### DIFF
--- a/src/utils/ProxyUtils.js
+++ b/src/utils/ProxyUtils.js
@@ -38,11 +38,7 @@ const parseProxyFromEnv = () => {
             .map(s => s.trim())
             .filter(Boolean);
         finalBypass = [...new Set([...defaultBypass, ...userBypass])];
-    } else {
-        // If user didn't specify NO_PROXY, we should at least bypass local addresses
-        // to prevent WebSocket connection failures when proxy is set.
     }
-
     const bypassString = finalBypass.join(",");
 
     // Playwright expects: { server, bypass?, username?, password? }


### PR DESCRIPTION
- 禁止内部流量被代理，导致websocket连接失败

---

- Avoid proxying internal traffic to prevent WebSocket connection failure.

---

- fix #66 