### PR TITLE
feat: apply default safety settings for native Google POST requests

### DIFF
--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -2665,6 +2665,16 @@ class RequestHandler {
             }
         }
 
+        // Apply safety settings for native Google requests (only if not already provided)
+        if (req.method === "POST" && bodyObj && bodyObj.contents && !bodyObj.safetySettings) {
+            bodyObj.safetySettings = [
+                { category: "HARM_CATEGORY_HARASSMENT", threshold: "BLOCK_NONE" },
+                { category: "HARM_CATEGORY_HATE_SPEECH", threshold: "BLOCK_NONE" },
+                { category: "HARM_CATEGORY_SEXUALLY_EXPLICIT", threshold: "BLOCK_NONE" },
+                { category: "HARM_CATEGORY_DANGEROUS_CONTENT", threshold: "BLOCK_NONE" },
+            ];
+        }
+
         this.logger.debug(`[Proxy] Debug: Final Gemini Request (Google Native) = ${JSON.stringify(bodyObj, null, 2)}`);
 
         return {


### PR DESCRIPTION
给gemini接口添加  `BLOCK_NONE` 的安全设置(若不存在)，OpenAI和claude接口已有添加。

Add the `BLOCK_NONE` safety setting to the Gemini interface (if it doesn't exist). The OpenAI and Claude interfaces already have it added.

- fix #100