### PR TITLE
chore: extend cookie maxAge to one week for improved session persistence

### DIFF
--- a/src/routes/WebRoutes.js
+++ b/src/routes/WebRoutes.js
@@ -46,7 +46,7 @@ class WebRoutes {
             cookie: {
                 httpOnly: true,
 
-                maxAge: 86400000,
+                maxAge: 604800000,
 
                 sameSite: "lax",
                 // This allows HTTP access in production if HTTPS is not configured


### PR DESCRIPTION
- Increased the `maxAge` property for session cookies from 1 day (86400000 ms) to 7 days (604800000 ms) in `WebRoutes.js`, allowing users to stay logged in longer.
- 将 WebRoutes.js 中会话 cookie 的 maxAge 属性从 1 天（86400000 毫秒）增加到 7 天（604800000 毫秒），允许用户更长时间保持登录状态。

- fix #107 