### PR TITLE
feat: support model suffix overrides for streaming mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ services:
 编辑 `configs/models.json` 以自定义可用模型及其设置。
 
 > 💡 **提示：** 思考参数预留了通过模型后缀名来设置的功能，支持在模型名后面通过 `-THINKING_LEVEL` 或 `(THINKING_LEVEL)` 来设置（`THINKING_LEVEL` 支持 `high`、`low`、`medium`、`minimal`，不区分大小写）。例如：`gemini-3-flash-preview(minimal)` 或 `gemini-3-flash-preview-minimal`。
+>
+> 真假流式也支持通过模型名后缀覆盖，支持在模型名最后追加 `-real` 或 `-fake`。该后缀优先级高于系统的真假流式，但只会在流式请求中生效。例如：`gemini-3-flash-preview-fake`。若和思考后缀同时使用，真假流后缀必须放在最后，例如：`gemini-3-flash-preview-minimal-fake` 或 `gemini-3-flash-preview(minimal)-real`。
 
 ## 📄 许可证
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -268,6 +268,8 @@ To simplify the login process for multiple accounts, you can configure the `user
 Edit `configs/models.json` to customize available models and their settings.
 
 > 💡 **Tip:** The thinking parameter reserves the function to be set via the model suffix. It supports setting the thinking level by appending `-THINKING_LEVEL` or `(THINKING_LEVEL)` to the model name (`THINKING_LEVEL` supports `high`, `low`, `medium`, `minimal`, case-insensitive). For example: `gemini-3-flash-preview(minimal)` or `gemini-3-flash-preview-minimal`.
+>
+> Streaming mode can also be overridden by appending `-real` or `-fake` to the end of the model name. This override has higher priority than the system streaming mode, but it only takes effect for streaming requests. For example: `gemini-3-flash-preview-fake`. When used together, the streaming suffix must be last, for example: `gemini-3-flash-preview-minimal-fake` or `gemini-3-flash-preview(minimal)-real`.
 
 ## 📄 License
 

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -37,6 +37,30 @@ class FormatConverter {
     };
 
     /**
+     * Parse streaming mode suffix from model name.
+     * Only supports the LAST hyphen token: `-real` or `-fake` (case-insensitive).
+     *
+     * Examples:
+     * - gemini-3-flash-preview-minimal-fake -> { cleanModelName: "gemini-3-flash-preview-minimal", streamingMode: "fake" }
+     * - gemini-3-flash-preview-fake-minimal -> no match (streaming suffix must be last)
+     *
+     * @param {string} modelName - Original model name
+     * @returns {{ cleanModelName: string, streamingMode: ("real"|"fake"|null) }}
+     */
+    static parseModelStreamingModeSuffix(modelName) {
+        if (!modelName || typeof modelName !== "string") {
+            return { cleanModelName: modelName, streamingMode: null };
+        }
+
+        const match = modelName.match(/^(.+)-(real|fake)$/i);
+        if (!match) {
+            return { cleanModelName: modelName, streamingMode: null };
+        }
+
+        return { cleanModelName: match[1], streamingMode: match[2].toLowerCase() };
+    }
+
+    /**
      * Parse thinkingLevel suffix from model name
      * Supports two formats:
      *   - Parenthesis format: gemini-3-flash-preview(minimal), gemini-3-pro-preview(high)
@@ -395,15 +419,26 @@ class FormatConverter {
     /**
      * Convert OpenAI request format to Google Gemini format
      * @param {object} openaiBody - OpenAI format request body
-     * @returns {Promise<{ googleRequest: object, cleanModelName: string }>} - Converted request and cleaned model name
+     * @returns {Promise<{ googleRequest: object, cleanModelName: string, modelStreamingMode: ("real"|"fake"|null) }>}
+     *          - modelStreamingMode: Streaming mode override parsed from model name suffix, or null
      */
     async translateOpenAIToGoogle(openaiBody) {
         this.logger.info("[Adapter] Starting translation of OpenAI request format to Google format...");
 
-        // Parse thinkingLevel suffix from model name (e.g., gemini-3-flash-preview-minimal or gemini-3-flash-preview(low))
+        // Parse model suffixes in fixed order:
+        // 1) streaming override: only `-real` / `-fake` at the end
+        // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
         const rawModel = openaiBody.model || "gemini-2.5-flash-lite";
-        const { cleanModelName, thinkingLevel: modelThinkingLevel } = FormatConverter.parseModelThinkingLevel(rawModel);
+        const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
+            FormatConverter.parseModelStreamingModeSuffix(rawModel);
+        const { cleanModelName, thinkingLevel: modelThinkingLevel } =
+            FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
+        if (modelStreamingMode) {
+            this.logger.info(
+                `[Adapter] Detected streamingMode suffix in model name: "${rawModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+            );
+        }
         if (modelThinkingLevel) {
             this.logger.info(
                 `[Adapter] Detected thinkingLevel suffix in model name: "${rawModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
@@ -841,7 +876,7 @@ class FormatConverter {
 
         this._finalizeGoogleRequest(googleRequest);
         this.logger.info("[Adapter] OpenAI to Google translation complete.");
-        return { cleanModelName, googleRequest };
+        return { cleanModelName, googleRequest, modelStreamingMode };
     }
 
     /**
@@ -1920,15 +1955,26 @@ class FormatConverter {
     /**
      * Convert Claude API request format to Google Gemini format
      * @param {object} claudeBody - Claude API format request body
-     * @returns {Promise<{ googleRequest: object, cleanModelName: string }>} - Converted request and cleaned model name
+     * @returns {Promise<{ googleRequest: object, cleanModelName: string, modelStreamingMode: ("real"|"fake"|null) }>}
+     *          - modelStreamingMode: Streaming mode override parsed from model name suffix, or null
      */
     async translateClaudeToGoogle(claudeBody) {
         this.logger.info("[Adapter] Starting translation of Claude request format to Google format...");
 
-        // Parse thinkingLevel suffix from model name
+        // Parse model suffixes in fixed order:
+        // 1) streaming override: only `-real` / `-fake` at the end
+        // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
         const rawModel = claudeBody.model || "gemini-2.5-flash-lite";
-        const { cleanModelName, thinkingLevel: modelThinkingLevel } = FormatConverter.parseModelThinkingLevel(rawModel);
+        const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
+            FormatConverter.parseModelStreamingModeSuffix(rawModel);
+        const { cleanModelName, thinkingLevel: modelThinkingLevel } =
+            FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
+        if (modelStreamingMode) {
+            this.logger.info(
+                `[Adapter] Detected streamingMode suffix in model name: "${rawModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+            );
+        }
         if (modelThinkingLevel) {
             this.logger.info(
                 `[Adapter] Detected thinkingLevel suffix in model name: "${rawModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
@@ -2337,7 +2383,7 @@ class FormatConverter {
 
         this._finalizeGoogleRequest(googleRequest);
         this.logger.info("[Adapter] Claude to Google translation complete.");
-        return { cleanModelName, googleRequest };
+        return { cleanModelName, googleRequest, modelStreamingMode };
     }
 
     /**
@@ -2683,15 +2729,26 @@ class FormatConverter {
      * Convert OpenAI Response API request format to Google Gemini format
      * Response API uses different structure: input instead of messages, instructions instead of system message
      * @param {object} responseBody - OpenAI Response API format request body
-     * @returns {Promise<{ googleRequest: object, cleanModelName: string }>} - Converted request and cleaned model name
+     * @returns {Promise<{ googleRequest: object, cleanModelName: string, modelStreamingMode: ("real"|"fake"|null) }>}
+     *          - modelStreamingMode: Streaming mode override parsed from model name suffix, or null
      */
     async translateOpenAIResponseToGoogle(responseBody) {
         this.logger.info("[Adapter] Starting translation of OpenAI Response API request format to Google format...");
 
-        // Parse thinkingLevel suffix from model name
+        // Parse model suffixes in fixed order:
+        // 1) streaming override: only `-real` / `-fake` at the end
+        // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
         const rawModel = responseBody.model || "gemini-2.5-flash-lite";
-        const { cleanModelName, thinkingLevel: modelThinkingLevel } = FormatConverter.parseModelThinkingLevel(rawModel);
+        const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
+            FormatConverter.parseModelStreamingModeSuffix(rawModel);
+        const { cleanModelName, thinkingLevel: modelThinkingLevel } =
+            FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
+        if (modelStreamingMode) {
+            this.logger.info(
+                `[Adapter] Detected streamingMode suffix in model name: "${rawModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+            );
+        }
         if (modelThinkingLevel) {
             this.logger.info(
                 `[Adapter] Detected thinkingLevel suffix in model name: "${rawModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
@@ -3177,7 +3234,7 @@ class FormatConverter {
 
         this._finalizeGoogleRequest(googleRequest);
         this.logger.info("[Adapter] OpenAI Response API to Google translation complete.");
-        return { cleanModelName, googleRequest };
+        return { cleanModelName, googleRequest, modelStreamingMode };
     }
 }
 

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -425,6 +425,9 @@ class FormatConverter {
     async translateOpenAIToGoogle(openaiBody) {
         this.logger.info("[Adapter] Starting translation of OpenAI request format to Google format...");
 
+        // [DEBUG] Log incoming messages for troubleshooting
+        this.logger.debug(`[Adapter] Debug: incoming OpenAI Body = ${JSON.stringify(openaiBody, null, 2)}`);
+
         // Parse model suffixes in fixed order:
         // 1) streaming override: only `-real` / `-fake` at the end
         // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
@@ -441,12 +444,9 @@ class FormatConverter {
         }
         if (modelThinkingLevel) {
             this.logger.info(
-                `[Adapter] Detected thinkingLevel suffix in model name: "${rawModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
+                `[Adapter] Detected thinkingLevel suffix in model name: "${streamStrippedModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
             );
         }
-
-        // [DEBUG] Log incoming messages for troubleshooting
-        this.logger.debug(`[Adapter] Debug: incoming OpenAI Body = ${JSON.stringify(openaiBody, null, 2)}`);
 
         let systemInstruction = null;
         const googleContents = [];
@@ -754,9 +754,7 @@ class FormatConverter {
                 thinkingConfig = {};
             }
             thinkingConfig.thinkingLevel = modelThinkingLevel;
-            this.logger.info(
-                `[Adapter] Applied thinkingLevel from model name suffix: ${modelThinkingLevel} (overriding any existing value)`
-            );
+            this.logger.info(`[Adapter] Applied thinkingLevel from model name suffix: ${modelThinkingLevel}`);
         }
 
         if (thinkingConfig) {
@@ -1961,6 +1959,9 @@ class FormatConverter {
     async translateClaudeToGoogle(claudeBody) {
         this.logger.info("[Adapter] Starting translation of Claude request format to Google format...");
 
+        // [DEBUG] Log incoming messages
+        this.logger.debug(`[Adapter] Debug: incoming Claude Body = ${JSON.stringify(claudeBody, null, 2)}`);
+
         // Parse model suffixes in fixed order:
         // 1) streaming override: only `-real` / `-fake` at the end
         // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
@@ -1977,12 +1978,9 @@ class FormatConverter {
         }
         if (modelThinkingLevel) {
             this.logger.info(
-                `[Adapter] Detected thinkingLevel suffix in model name: "${rawModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
+                `[Adapter] Detected thinkingLevel suffix in model name: "${streamStrippedModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
             );
         }
-
-        // [DEBUG] Log incoming messages
-        this.logger.debug(`[Adapter] Debug: incoming Claude Body = ${JSON.stringify(claudeBody, null, 2)}`);
 
         let systemInstruction = null;
         const googleContents = [];
@@ -2735,6 +2733,10 @@ class FormatConverter {
     async translateOpenAIResponseToGoogle(responseBody) {
         this.logger.info("[Adapter] Starting translation of OpenAI Response API request format to Google format...");
 
+        this.logger.debug(
+            `[Adapter] Debug: incoming OpenAI Response API Body = ${JSON.stringify(responseBody, null, 2)}`
+        );
+
         // Parse model suffixes in fixed order:
         // 1) streaming override: only `-real` / `-fake` at the end
         // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
@@ -2751,13 +2753,9 @@ class FormatConverter {
         }
         if (modelThinkingLevel) {
             this.logger.info(
-                `[Adapter] Detected thinkingLevel suffix in model name: "${rawModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
+                `[Adapter] Detected thinkingLevel suffix in model name: "${streamStrippedModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
             );
         }
-
-        this.logger.debug(
-            `[Adapter] Debug: incoming OpenAI Response API Body = ${JSON.stringify(responseBody, null, 2)}`
-        );
 
         const googleContents = [];
         let systemInstructionText = "";
@@ -3030,9 +3028,7 @@ class FormatConverter {
                 thinkingConfig = {};
             }
             thinkingConfig.thinkingLevel = modelThinkingLevel;
-            this.logger.info(
-                `[Adapter] Applied thinkingLevel from model name suffix: ${modelThinkingLevel} (overriding any existing value)`
-            );
+            this.logger.info(`[Adapter] Applied thinkingLevel from model name suffix: ${modelThinkingLevel}`);
         }
 
         if (thinkingConfig) {

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -623,6 +623,7 @@ class RequestHandler {
     // Process standard Google API requests
     async processRequest(req, res) {
         const requestId = this._generateRequestId();
+        res.__proxyResponseStreamMode = null;
 
         // Check current account's browser connection
         if (!this.connectionRegistry.getConnectionByAuth(this.currentAuthIndex)) {
@@ -665,6 +666,7 @@ class RequestHandler {
         const wantsStreamByHeader = req.headers.accept && req.headers.accept.includes("text/event-stream");
         const wantsStreamByPath = req.path.includes(":streamGenerateContent");
         const wantsStream = wantsStreamByHeader || wantsStreamByPath;
+        res.__proxyResponseStreamMode = wantsStream ? proxyRequest.streaming_mode : null;
 
         try {
             // Create message queue inside try-catch to handle invalid authIndex
@@ -763,6 +765,7 @@ class RequestHandler {
     // Process OpenAI format requests
     async processOpenAIRequest(req, res) {
         const requestId = this._generateRequestId();
+        res.__proxyResponseStreamMode = null;
 
         // Check current account's browser connection
         if (!this.connectionRegistry.getConnectionByAuth(this.currentAuthIndex)) {
@@ -823,6 +826,7 @@ class RequestHandler {
             streaming_mode: useRealStream ? "real" : "fake",
         };
         this._initializeProxyRequestAttempt(proxyRequest);
+        res.__proxyResponseStreamMode = isOpenAIStream ? (useRealStream ? "real" : "fake") : null;
 
         try {
             // Create message queue inside try-catch to handle invalid authIndex
@@ -1084,6 +1088,7 @@ class RequestHandler {
     // Process OpenAI Response API format requests
     async processOpenAIResponseRequest(req, res) {
         const requestId = this._generateRequestId();
+        res.__proxyResponseStreamMode = null;
 
         // Check current account's browser connection
         if (!this.connectionRegistry.getConnectionByAuth(this.currentAuthIndex)) {
@@ -1193,6 +1198,7 @@ class RequestHandler {
             streaming_mode: useRealStream ? "real" : "fake",
         };
         this._initializeProxyRequestAttempt(proxyRequest);
+        res.__proxyResponseStreamMode = isOpenAIStream ? (useRealStream ? "real" : "fake") : null;
 
         try {
             // Create message queue inside try-catch to handle invalid authIndex
@@ -1468,6 +1474,7 @@ class RequestHandler {
     // Process Claude API format requests
     async processClaudeRequest(req, res) {
         const requestId = this._generateRequestId();
+        res.__proxyResponseStreamMode = null;
 
         // Check current account's browser connection
         if (!this.connectionRegistry.getConnectionByAuth(this.currentAuthIndex)) {
@@ -1531,6 +1538,7 @@ class RequestHandler {
             streaming_mode: useRealStream ? "real" : "fake",
         };
         this._initializeProxyRequestAttempt(proxyRequest);
+        res.__proxyResponseStreamMode = isClaudeStream ? (useRealStream ? "real" : "fake") : null;
 
         try {
             // Create message queue inside try-catch to handle invalid authIndex
@@ -3362,8 +3370,8 @@ class RequestHandler {
                         const writeErrorMsg = String(writeError?.message ?? writeError);
                         this.logger.error(`[Request] Failed to write error to stream: ${writeErrorMsg}`);
                     }
-                } else if (this.serverSystem.streamingMode === "fake") {
-                    // Fake streaming mode - try to send error chunk
+                } else if (res.__proxyResponseStreamMode === "fake") {
+                    // Request-scoped fake stream mode - try to send an SSE-style error chunk
                     try {
                         this._sendErrorChunkToClient(res, `Processing failed: ${errorMsg}`);
                     } catch (writeError) {

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -3559,21 +3559,22 @@ class RequestHandler {
             const pathSuffix = modelPathMatch[3];
 
             const FormatConverter = require("./FormatConverter");
-            const { cleanModelName: streamStrippedModel, streamingMode } =
+            const { cleanModelName: streamStrippedModel, streamingMode: parsedStreamingMode } =
                 FormatConverter.parseModelStreamingModeSuffix(rawModelName);
-            const { cleanModelName, thinkingLevel } = FormatConverter.parseModelThinkingLevel(streamStrippedModel);
+            const { cleanModelName, thinkingLevel: parsedThinkingLevel } =
+                FormatConverter.parseModelThinkingLevel(streamStrippedModel);
+            modelStreamingMode = parsedStreamingMode;
+            modelThinkingLevel = parsedThinkingLevel;
 
-            if (streamingMode) {
-                modelStreamingMode = streamingMode;
+            if (modelStreamingMode) {
                 this.logger.info(
-                    `[Proxy] Detected streamingMode suffix in model path: "${rawModelName}" -> model="${streamStrippedModel}", streamingMode="${streamingMode}"`
+                    `[Proxy] Detected streamingMode suffix in model path: "${rawModelName}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
                 );
             }
 
-            if (thinkingLevel) {
-                modelThinkingLevel = thinkingLevel;
+            if (modelThinkingLevel) {
                 this.logger.info(
-                    `[Proxy] Detected thinkingLevel suffix in model path: "${rawModelName}" -> model="${cleanModelName}", thinkingLevel="${thinkingLevel}"`
+                    `[Proxy] Detected thinkingLevel suffix in model path: "${streamStrippedModel}" -> model="${cleanModelName}", thinkingLevel="${modelThinkingLevel}"`
                 );
             }
 

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -663,9 +663,7 @@ class RequestHandler {
         proxyRequest.is_generative = isGenerativeRequest;
         this._initializeProxyRequestAttempt(proxyRequest);
 
-        const wantsStreamByHeader = req.headers.accept && req.headers.accept.includes("text/event-stream");
-        const wantsStreamByPath = req.path.includes(":streamGenerateContent");
-        const wantsStream = wantsStreamByHeader || wantsStreamByPath;
+        const wantsStream = req.path.includes(":streamGenerateContent");
         res.__proxyResponseStreamMode = wantsStream ? proxyRequest.streaming_mode : null;
 
         try {

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -677,9 +677,9 @@ class RequestHandler {
 
             if (wantsStream) {
                 this.logger.info(
-                    `[Request] Client enabled streaming (${this.serverSystem.streamingMode}), entering streaming processing mode...`
+                    `[Request] Client enabled streaming (${proxyRequest.streaming_mode}), entering streaming processing mode...`
                 );
-                if (this.serverSystem.streamingMode === "fake") {
+                if (proxyRequest.streaming_mode === "fake") {
                     await this._handlePseudoStreamResponse(proxyRequest, messageQueue, req, res);
                 } else {
                     await this._handleRealStreamResponse(proxyRequest, messageQueue, req, res);
@@ -782,7 +782,6 @@ class RequestHandler {
 
         const isOpenAIStream = req.body.stream === true;
         const systemStreamMode = this.serverSystem.streamingMode;
-        const useRealStream = isOpenAIStream && systemStreamMode === "real";
 
         // Handle usage counting
         const usageCount = this.authSwitcher.incrementUsageCount();
@@ -798,15 +797,19 @@ class RequestHandler {
         }
 
         // Translate OpenAI format to Google format (also handles model name suffix parsing)
-        let googleBody, model;
+        let googleBody, model, modelStreamingMode;
         try {
             const result = await this.formatConverter.translateOpenAIToGoogle(req.body);
             googleBody = result.googleRequest;
             model = result.cleanModelName;
+            modelStreamingMode = result.modelStreamingMode || null;
         } catch (error) {
             this.logger.error(`[Adapter] OpenAI request translation failed: ${error.message}`);
             return this._sendErrorResponse(res, 400, "Invalid OpenAI request format.");
         }
+
+        const effectiveStreamMode = modelStreamingMode || systemStreamMode;
+        const useRealStream = isOpenAIStream && effectiveStreamMode === "real";
 
         const googleEndpoint = useRealStream ? "streamGenerateContent" : "generateContent";
         const proxyRequest = {
@@ -1149,7 +1152,6 @@ class RequestHandler {
             Object.entries(responseDefaultsRaw).filter(([, v]) => v !== undefined)
         );
         const systemStreamMode = this.serverSystem.streamingMode;
-        const useRealStream = isOpenAIStream && systemStreamMode === "real";
 
         // Handle usage counting
         const usageCount = this.authSwitcher.incrementUsageCount();
@@ -1165,15 +1167,19 @@ class RequestHandler {
         }
 
         // Translate OpenAI Response format to Google format
-        let googleBody, model;
+        let googleBody, model, modelStreamingMode;
         try {
             const result = await this.formatConverter.translateOpenAIResponseToGoogle(req.body);
             googleBody = result.googleRequest;
             model = result.cleanModelName;
+            modelStreamingMode = result.modelStreamingMode || null;
         } catch (error) {
             this.logger.error(`[Adapter] OpenAI Response request translation failed: ${error.message}`);
             return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.");
         }
+
+        const effectiveStreamMode = modelStreamingMode || systemStreamMode;
+        const useRealStream = isOpenAIStream && effectiveStreamMode === "real";
 
         const googleEndpoint = useRealStream ? "streamGenerateContent" : "generateContent";
         const proxyRequest = {
@@ -1484,7 +1490,6 @@ class RequestHandler {
 
         const isClaudeStream = req.body.stream === true;
         const systemStreamMode = this.serverSystem.streamingMode;
-        const useRealStream = isClaudeStream && systemStreamMode === "real";
 
         // Handle usage counting
         const usageCount = this.authSwitcher.incrementUsageCount();
@@ -1500,15 +1505,19 @@ class RequestHandler {
         }
 
         // Translate Claude format to Google format
-        let googleBody, model;
+        let googleBody, model, modelStreamingMode;
         try {
             const result = await this.formatConverter.translateClaudeToGoogle(req.body);
             googleBody = result.googleRequest;
             model = result.cleanModelName;
+            modelStreamingMode = result.modelStreamingMode || null;
         } catch (error) {
             this.logger.error(`[Adapter] Claude request translation failed: ${error.message}`);
             return this._sendClaudeErrorResponse(res, 400, "invalid_request_error", "Invalid Claude request format.");
         }
+
+        const effectiveStreamMode = modelStreamingMode || systemStreamMode;
+        const useRealStream = isClaudeStream && effectiveStreamMode === "real";
 
         const googleEndpoint = useRealStream ? "streamGenerateContent" : "generateContent";
         const proxyRequest = {
@@ -3534,6 +3543,7 @@ class RequestHandler {
             /^(\/v1beta\/models\/)([^:]+)(:(generateContent|streamGenerateContent).*)$/
         );
         let modelThinkingLevel = null;
+        let modelStreamingMode = null;
 
         if (modelPathMatch) {
             const pathPrefix = modelPathMatch[1];
@@ -3541,14 +3551,27 @@ class RequestHandler {
             const pathSuffix = modelPathMatch[3];
 
             const FormatConverter = require("./FormatConverter");
-            const { cleanModelName, thinkingLevel } = FormatConverter.parseModelThinkingLevel(rawModelName);
+            const { cleanModelName: streamStrippedModel, streamingMode } =
+                FormatConverter.parseModelStreamingModeSuffix(rawModelName);
+            const { cleanModelName, thinkingLevel } = FormatConverter.parseModelThinkingLevel(streamStrippedModel);
+
+            if (streamingMode) {
+                modelStreamingMode = streamingMode;
+                this.logger.info(
+                    `[Proxy] Detected streamingMode suffix in model path: "${rawModelName}" -> model="${streamStrippedModel}", streamingMode="${streamingMode}"`
+                );
+            }
 
             if (thinkingLevel) {
                 modelThinkingLevel = thinkingLevel;
-                cleanPath = `${pathPrefix}${cleanModelName}${pathSuffix}`;
                 this.logger.info(
                     `[Proxy] Detected thinkingLevel suffix in model path: "${rawModelName}" -> model="${cleanModelName}", thinkingLevel="${thinkingLevel}"`
                 );
+            }
+
+            // Always strip recognized directives from path model name
+            if (cleanModelName !== rawModelName) {
+                cleanPath = `${pathPrefix}${cleanModelName}${pathSuffix}`;
             }
         }
 
@@ -3657,6 +3680,8 @@ class RequestHandler {
 
         this.logger.debug(`[Proxy] Debug: Final Gemini Request (Google Native) = ${JSON.stringify(bodyObj, null, 2)}`);
 
+        const effectiveStreamMode = modelStreamingMode || this.serverSystem.streamingMode;
+
         return {
             body: req.method !== "GET" ? JSON.stringify(bodyObj) : undefined,
             headers: req.headers,
@@ -3667,7 +3692,7 @@ class RequestHandler {
             path: cleanPath,
             query_params: req.query || {},
             request_id: requestId,
-            streaming_mode: this.serverSystem.streamingMode,
+            streaming_mode: effectiveStreamMode,
         };
     }
 


### PR DESCRIPTION
支持通过模型名后缀覆盖真假流式，支持在模型名最后追加 `-real` 或 `-fake`。该后缀优先级高于系统的真假流式，但只会在流式请求中生效。例如：`gemini-3-flash-preview-fake`。若和思考后缀同时使用，真假流后缀必须放在最后，例如：`gemini-3-flash-preview-minimal-fake` 或 `gemini-3-flash-preview(minimal)-real`。

Streaming mode can be overridden by appending `-real` or `-fake` to the end of the model name. This override has higher priority than the system streaming mode, but it only takes effect for streaming requests. For example: `gemini-3-flash-preview-fake`. When used together, the streaming suffix must be last, for example: `gemini-3-flash-preview-minimal-fake` or `gemini-3-flash-preview(minimal)-real`.

- close #91 