### PR TITLE
feat: add support for web search suffix in model names

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ services:
 > 💡 **提示：** 思考参数预留了通过模型后缀名来设置的功能，支持在模型名后面通过 `-THINKING_LEVEL` 或 `(THINKING_LEVEL)` 来设置（`THINKING_LEVEL` 支持 `high`、`low`、`medium`、`minimal`，不区分大小写）。例如：`gemini-3-flash-preview(minimal)` 或 `gemini-3-flash-preview-minimal`。
 >
 > 真假流式也支持通过模型名后缀覆盖，支持在模型名最后追加 `-real` 或 `-fake`。该后缀优先级高于系统的真假流式，但只会在流式请求中生效。例如：`gemini-3-flash-preview-fake`。若和思考后缀同时使用，真假流后缀必须放在最后，例如：`gemini-3-flash-preview-minimal-fake` 或 `gemini-3-flash-preview(minimal)-real`。
+>
+> 联网搜索也支持通过模型名后缀强制开启，支持在模型名最后追加 `-search`。例如：`gemini-3-flash-preview-search`。若和其他后缀同时使用，`-search` 必须放在最末尾，例如：`gemini-3-flash-preview-minimal-search`、`gemini-3-flash-preview-real-search` 或 `gemini-3-flash-preview(minimal)-fake-search`。
 
 ## 📄 许可证
 

--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ services:
 
 > 💡 **提示：** 思考参数预留了通过模型后缀名来设置的功能，支持在模型名后面通过 `-THINKING_LEVEL` 或 `(THINKING_LEVEL)` 来设置（`THINKING_LEVEL` 支持 `high`、`low`、`medium`、`minimal`，不区分大小写）。例如：`gemini-3-flash-preview(minimal)` 或 `gemini-3-flash-preview-minimal`。
 >
-> 真假流式也支持通过模型名后缀覆盖，支持在模型名最后追加 `-real` 或 `-fake`。该后缀优先级高于系统的真假流式，但只会在流式请求中生效。例如：`gemini-3-flash-preview-fake`。若和思考后缀同时使用，真假流后缀必须放在最后，例如：`gemini-3-flash-preview-minimal-fake` 或 `gemini-3-flash-preview(minimal)-real`。
+> 真假流式也支持通过模型名后缀覆盖，支持追加 `-real` 或 `-fake`。该后缀优先级高于系统的真假流式，但只会在流式请求中生效。例如：`gemini-3-flash-preview-fake`。若和思考后缀同时使用，真假流后缀应放在思考后缀之后，例如：`gemini-3-flash-preview-minimal-fake` 或 `gemini-3-flash-preview(minimal)-real`。
 >
-> 联网搜索也支持通过模型名后缀强制开启，支持在模型名最后追加 `-search`。例如：`gemini-3-flash-preview-search`。若和其他后缀同时使用，`-search` 必须放在最末尾，例如：`gemini-3-flash-preview-minimal-search`、`gemini-3-flash-preview-real-search` 或 `gemini-3-flash-preview(minimal)-fake-search`。
+> 联网搜索也支持通过模型名后缀强制开启，支持在模型名最后追加 `-search`。例如：`gemini-3-flash-preview-search`。若和其他后缀同时使用，`-search` 必须放在最末尾；完整组合顺序仍为“思考 -> 流式 -> 搜索”，例如：`gemini-3-flash-preview-minimal-search`、`gemini-3-flash-preview-real-search` 或 `gemini-3-flash-preview(minimal)-fake-search`。
 
 ## 📄 许可证
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -269,9 +269,9 @@ Edit `configs/models.json` to customize available models and their settings.
 
 > 💡 **Tip:** The thinking parameter reserves the function to be set via the model suffix. It supports setting the thinking level by appending `-THINKING_LEVEL` or `(THINKING_LEVEL)` to the model name (`THINKING_LEVEL` supports `high`, `low`, `medium`, `minimal`, case-insensitive). For example: `gemini-3-flash-preview(minimal)` or `gemini-3-flash-preview-minimal`.
 >
-> Streaming mode can also be overridden by appending `-real` or `-fake` to the end of the model name. This override has higher priority than the system streaming mode, but it only takes effect for streaming requests. For example: `gemini-3-flash-preview-fake`. When used together, the streaming suffix must be last, for example: `gemini-3-flash-preview-minimal-fake` or `gemini-3-flash-preview(minimal)-real`.
+> Streaming mode can also be overridden with `-real` or `-fake`. This override has higher priority than the system streaming mode, but it only takes effect for streaming requests. For example: `gemini-3-flash-preview-fake`. When used together with a thinking suffix, the streaming suffix should come after the thinking suffix, for example: `gemini-3-flash-preview-minimal-fake` or `gemini-3-flash-preview(minimal)-real`.
 >
-> Web search can also be forced on by appending `-search` to the end of the model name. For example: `gemini-3-flash-preview-search`. When combined with other suffixes, `-search` must be the final suffix, for example: `gemini-3-flash-preview-minimal-search`, `gemini-3-flash-preview-real-search`, or `gemini-3-flash-preview(minimal)-fake-search`.
+> Web search can also be forced on by appending `-search` to the end of the model name. For example: `gemini-3-flash-preview-search`. When combined with other suffixes, `-search` must be the final suffix; the full combined order remains `thinking -> streaming -> search`, for example: `gemini-3-flash-preview-minimal-search`, `gemini-3-flash-preview-real-search`, or `gemini-3-flash-preview(minimal)-fake-search`.
 
 ## 📄 License
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -270,6 +270,8 @@ Edit `configs/models.json` to customize available models and their settings.
 > 💡 **Tip:** The thinking parameter reserves the function to be set via the model suffix. It supports setting the thinking level by appending `-THINKING_LEVEL` or `(THINKING_LEVEL)` to the model name (`THINKING_LEVEL` supports `high`, `low`, `medium`, `minimal`, case-insensitive). For example: `gemini-3-flash-preview(minimal)` or `gemini-3-flash-preview-minimal`.
 >
 > Streaming mode can also be overridden by appending `-real` or `-fake` to the end of the model name. This override has higher priority than the system streaming mode, but it only takes effect for streaming requests. For example: `gemini-3-flash-preview-fake`. When used together, the streaming suffix must be last, for example: `gemini-3-flash-preview-minimal-fake` or `gemini-3-flash-preview(minimal)-real`.
+>
+> Web search can also be forced on by appending `-search` to the end of the model name. For example: `gemini-3-flash-preview-search`. When combined with other suffixes, `-search` must be the final suffix, for example: `gemini-3-flash-preview-minimal-search`, `gemini-3-flash-preview-real-search`, or `gemini-3-flash-preview(minimal)-fake-search`.
 
 ## 📄 License
 

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -62,11 +62,15 @@ class FormatConverter {
 
     /**
      * Parse streaming mode suffix from model name.
-     * Only supports the LAST hyphen token: `-real` or `-fake` (case-insensitive).
+     * Supports `-real` or `-fake` (case-insensitive) after any thinking suffix has been applied,
+     * and before an optional trailing `-search` suffix is stripped. The combined suffix order is:
+     * thinking -> streaming -> search.
      *
      * Examples:
      * - gemini-3-flash-preview-minimal-fake -> { cleanModelName: "gemini-3-flash-preview-minimal", streamingMode: "fake" }
-     * - gemini-3-flash-preview-fake-minimal -> no match (streaming suffix must be last)
+     * - gemini-3-flash-preview(minimal)-fake -> { cleanModelName: "gemini-3-flash-preview(minimal)", streamingMode: "fake" }
+     * - gemini-3-flash-preview-fake-minimal -> no match (thinking must come before streaming)
+     * - gemini-3-flash-preview(minimal)-fake-search -> parse `-fake` after stripping the trailing `-search`
      *
      * @param {string} modelName - Original model name
      * @returns {{ cleanModelName: string, streamingMode: ("real"|"fake"|null) }}
@@ -474,10 +478,11 @@ class FormatConverter {
         // [DEBUG] Log incoming messages for troubleshooting
         this.logger.debug(`[Adapter] Debug: incoming OpenAI Body = ${JSON.stringify(openaiBody, null, 2)}`);
 
-        // Parse model suffixes in fixed order:
-        // 1) web search override: only `-search` at the end
-        // 2) streaming override: only `-real` / `-fake` at the end
-        // 3) thinkingLevel override: `-minimal` / `(minimal)` etc.
+        // Parse model suffixes in reverse stripping order:
+        // 1) web search override: only trailing `-search`
+        // 2) streaming override: trailing `-real` / `-fake` after any thinking suffix
+        // 3) thinkingLevel override: trailing `-minimal` / `(minimal)` etc.
+        // Combined user-facing suffix order: thinking -> streaming -> search
         const rawModel = openaiBody.model || "gemini-2.5-flash-lite";
         const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
             FormatConverter.parseModelWebSearchSuffix(rawModel);
@@ -937,6 +942,12 @@ class FormatConverter {
      * 2. Apply safety settings
      * 3. Log final request body
      * @param {object} googleRequest - The Gemini request object to finalize
+     * @param {object} [options={}] - Per-request tool injection overrides.
+     * @param {boolean} [options.forceWebSearch] - When truthy, force-enable `googleSearch` for this request even
+     * if `serverSystem.forceWebSearch` is disabled. Falsy values fall back to the global setting. Current callers
+     * use this for model-name-driven overrides such as the `-search` suffix.
+     * @param {boolean} [options.forceUrlContext] - When truthy, force-enable `urlContext` for this request even if
+     * `serverSystem.forceUrlContext` is disabled. Falsy values fall back to the global setting.
      * @private
      */
     _finalizeGoogleRequest(googleRequest, options = {}) {
@@ -2019,10 +2030,11 @@ class FormatConverter {
         // [DEBUG] Log incoming messages
         this.logger.debug(`[Adapter] Debug: incoming Claude Body = ${JSON.stringify(claudeBody, null, 2)}`);
 
-        // Parse model suffixes in fixed order:
-        // 1) web search override: only `-search` at the end
-        // 2) streaming override: only `-real` / `-fake` at the end
-        // 3) thinkingLevel override: `-minimal` / `(minimal)` etc.
+        // Parse model suffixes in reverse stripping order:
+        // 1) web search override: only trailing `-search`
+        // 2) streaming override: trailing `-real` / `-fake` after any thinking suffix
+        // 3) thinkingLevel override: trailing `-minimal` / `(minimal)` etc.
+        // Combined user-facing suffix order: thinking -> streaming -> search
         const rawModel = claudeBody.model || "gemini-2.5-flash-lite";
         const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
             FormatConverter.parseModelWebSearchSuffix(rawModel);
@@ -2802,10 +2814,11 @@ class FormatConverter {
             `[Adapter] Debug: incoming OpenAI Response API Body = ${JSON.stringify(responseBody, null, 2)}`
         );
 
-        // Parse model suffixes in fixed order:
-        // 1) web search override: only `-search` at the end
-        // 2) streaming override: only `-real` / `-fake` at the end
-        // 3) thinkingLevel override: `-minimal` / `(minimal)` etc.
+        // Parse model suffixes in reverse stripping order:
+        // 1) web search override: only trailing `-search`
+        // 2) streaming override: trailing `-real` / `-fake` after any thinking suffix
+        // 3) thinkingLevel override: trailing `-minimal` / `(minimal)` etc.
+        // Combined user-facing suffix order: thinking -> streaming -> search
         const rawModel = responseBody.model || "gemini-2.5-flash-lite";
         const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
             FormatConverter.parseModelWebSearchSuffix(rawModel);

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -62,15 +62,15 @@ class FormatConverter {
 
     /**
      * Parse streaming mode suffix from model name.
-     * Supports `-real` or `-fake` (case-insensitive) after any thinking suffix has been applied,
-     * and before an optional trailing `-search` suffix is stripped. The combined suffix order is:
-     * thinking -> streaming -> search.
+     * Only matches a trailing `-real` or `-fake` (case-insensitive).
+     * Callers should strip any trailing `-search` suffix before invoking this helper, so the
+     * combined suffix order remains: thinking -> streaming -> search.
      *
      * Examples:
      * - gemini-3-flash-preview-minimal-fake -> { cleanModelName: "gemini-3-flash-preview-minimal", streamingMode: "fake" }
      * - gemini-3-flash-preview(minimal)-fake -> { cleanModelName: "gemini-3-flash-preview(minimal)", streamingMode: "fake" }
      * - gemini-3-flash-preview-fake-minimal -> no match (thinking must come before streaming)
-     * - gemini-3-flash-preview(minimal)-fake-search -> parse `-fake` after stripping the trailing `-search`
+     * - gemini-3-flash-preview(minimal)-fake-search -> no direct match here; callers strip `-search` first
      *
      * @param {string} modelName - Original model name
      * @returns {{ cleanModelName: string, streamingMode: ("real"|"fake"|null) }}

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -37,6 +37,30 @@ class FormatConverter {
     };
 
     /**
+     * Parse web search suffix from model name.
+     * Only supports the LAST hyphen token: `-search` (case-insensitive).
+     *
+     * Examples:
+     * - gemini-3-flash-preview-minimal-search -> { cleanModelName: "gemini-3-flash-preview-minimal", forceWebSearch: true }
+     * - gemini-3-flash-preview-search-minimal -> no match (search suffix must be last)
+     *
+     * @param {string} modelName - Original model name
+     * @returns {{ cleanModelName: string, forceWebSearch: boolean }}
+     */
+    static parseModelWebSearchSuffix(modelName) {
+        if (!modelName || typeof modelName !== "string") {
+            return { cleanModelName: modelName, forceWebSearch: false };
+        }
+
+        const match = modelName.match(/^(.+)-search$/i);
+        if (!match) {
+            return { cleanModelName: modelName, forceWebSearch: false };
+        }
+
+        return { cleanModelName: match[1], forceWebSearch: true };
+    }
+
+    /**
      * Parse streaming mode suffix from model name.
      * Only supports the LAST hyphen token: `-real` or `-fake` (case-insensitive).
      *
@@ -170,6 +194,28 @@ class FormatConverter {
                         Object.prototype.hasOwnProperty.call(tool, toolKey)
                     )
             )
+        );
+    }
+
+    static hasGeminiToolKey(tool, keys) {
+        return !!(
+            tool &&
+            typeof tool === "object" &&
+            keys.some(toolKey => Object.prototype.hasOwnProperty.call(tool, toolKey))
+        );
+    }
+
+    static hasGeminiGoogleSearchTool(tools) {
+        return (
+            Array.isArray(tools) &&
+            tools.some(tool => FormatConverter.hasGeminiToolKey(tool, ["googleSearch", "google_search"]))
+        );
+    }
+
+    static hasGeminiUrlContextTool(tools) {
+        return (
+            Array.isArray(tools) &&
+            tools.some(tool => FormatConverter.hasGeminiToolKey(tool, ["urlContext", "url_context"]))
         );
     }
 
@@ -429,17 +475,25 @@ class FormatConverter {
         this.logger.debug(`[Adapter] Debug: incoming OpenAI Body = ${JSON.stringify(openaiBody, null, 2)}`);
 
         // Parse model suffixes in fixed order:
-        // 1) streaming override: only `-real` / `-fake` at the end
-        // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
+        // 1) web search override: only `-search` at the end
+        // 2) streaming override: only `-real` / `-fake` at the end
+        // 3) thinkingLevel override: `-minimal` / `(minimal)` etc.
         const rawModel = openaiBody.model || "gemini-2.5-flash-lite";
+        const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
+            FormatConverter.parseModelWebSearchSuffix(rawModel);
         const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
-            FormatConverter.parseModelStreamingModeSuffix(rawModel);
+            FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
         const { cleanModelName, thinkingLevel: modelThinkingLevel } =
             FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
+        if (modelForceWebSearch) {
+            this.logger.info(
+                `[Adapter] Detected webSearch suffix in model name: "${rawModel}" -> model="${searchStrippedModel}", forceWebSearch=true`
+            );
+        }
         if (modelStreamingMode) {
             this.logger.info(
-                `[Adapter] Detected streamingMode suffix in model name: "${rawModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                `[Adapter] Detected streamingMode suffix in model name: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
             );
         }
         if (modelThinkingLevel) {
@@ -872,7 +926,7 @@ class FormatConverter {
             }
         }
 
-        this._finalizeGoogleRequest(googleRequest);
+        this._finalizeGoogleRequest(googleRequest, { forceWebSearch: modelForceWebSearch });
         this.logger.info("[Adapter] OpenAI to Google translation complete.");
         return { cleanModelName, googleRequest, modelStreamingMode };
     }
@@ -885,9 +939,12 @@ class FormatConverter {
      * @param {object} googleRequest - The Gemini request object to finalize
      * @private
      */
-    _finalizeGoogleRequest(googleRequest) {
+    _finalizeGoogleRequest(googleRequest, options = {}) {
+        const forceWebSearch = options.forceWebSearch || this.serverSystem.forceWebSearch;
+        const forceUrlContext = options.forceUrlContext || this.serverSystem.forceUrlContext;
+
         // Force web search and URL context
-        if (this.serverSystem.forceWebSearch || this.serverSystem.forceUrlContext) {
+        if (forceWebSearch || forceUrlContext) {
             if (!googleRequest.tools) {
                 googleRequest.tools = [];
             }
@@ -895,8 +952,8 @@ class FormatConverter {
             const toolsToAdd = [];
 
             // Handle Google Search
-            if (this.serverSystem.forceWebSearch) {
-                const hasSearch = googleRequest.tools.some(t => t.googleSearch);
+            if (forceWebSearch) {
+                const hasSearch = FormatConverter.hasGeminiGoogleSearchTool(googleRequest.tools);
                 if (!hasSearch) {
                     googleRequest.tools.push({ googleSearch: {} });
                     toolsToAdd.push("googleSearch");
@@ -904,8 +961,8 @@ class FormatConverter {
             }
 
             // Handle URL Context
-            if (this.serverSystem.forceUrlContext) {
-                const hasUrlContext = googleRequest.tools.some(t => t.urlContext);
+            if (forceUrlContext) {
+                const hasUrlContext = FormatConverter.hasGeminiUrlContextTool(googleRequest.tools);
                 if (!hasUrlContext) {
                     googleRequest.tools.push({ urlContext: {} });
                     toolsToAdd.push("urlContext");
@@ -1963,17 +2020,25 @@ class FormatConverter {
         this.logger.debug(`[Adapter] Debug: incoming Claude Body = ${JSON.stringify(claudeBody, null, 2)}`);
 
         // Parse model suffixes in fixed order:
-        // 1) streaming override: only `-real` / `-fake` at the end
-        // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
+        // 1) web search override: only `-search` at the end
+        // 2) streaming override: only `-real` / `-fake` at the end
+        // 3) thinkingLevel override: `-minimal` / `(minimal)` etc.
         const rawModel = claudeBody.model || "gemini-2.5-flash-lite";
+        const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
+            FormatConverter.parseModelWebSearchSuffix(rawModel);
         const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
-            FormatConverter.parseModelStreamingModeSuffix(rawModel);
+            FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
         const { cleanModelName, thinkingLevel: modelThinkingLevel } =
             FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
+        if (modelForceWebSearch) {
+            this.logger.info(
+                `[Adapter] Detected webSearch suffix in model name: "${rawModel}" -> model="${searchStrippedModel}", forceWebSearch=true`
+            );
+        }
         if (modelStreamingMode) {
             this.logger.info(
-                `[Adapter] Detected streamingMode suffix in model name: "${rawModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                `[Adapter] Detected streamingMode suffix in model name: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
             );
         }
         if (modelThinkingLevel) {
@@ -2337,7 +2402,7 @@ class FormatConverter {
             // If web search tool was found, ensure googleSearch is added to tools
             if (hasWebSearchTool) {
                 if (!googleRequest.tools) googleRequest.tools = [];
-                if (!googleRequest.tools.some(t => t.googleSearch)) {
+                if (!FormatConverter.hasGeminiGoogleSearchTool(googleRequest.tools)) {
                     googleRequest.tools.push({ googleSearch: {} });
                 }
             }
@@ -2345,7 +2410,7 @@ class FormatConverter {
             // If web fetch tool was found, ensure urlContext is added to tools
             if (hasUrlContextTool) {
                 if (!googleRequest.tools) googleRequest.tools = [];
-                if (!googleRequest.tools.some(t => t.urlContext)) {
+                if (!FormatConverter.hasGeminiUrlContextTool(googleRequest.tools)) {
                     googleRequest.tools.push({ urlContext: {} });
                 }
             }
@@ -2379,7 +2444,7 @@ class FormatConverter {
             );
         }
 
-        this._finalizeGoogleRequest(googleRequest);
+        this._finalizeGoogleRequest(googleRequest, { forceWebSearch: modelForceWebSearch });
         this.logger.info("[Adapter] Claude to Google translation complete.");
         return { cleanModelName, googleRequest, modelStreamingMode };
     }
@@ -2738,17 +2803,25 @@ class FormatConverter {
         );
 
         // Parse model suffixes in fixed order:
-        // 1) streaming override: only `-real` / `-fake` at the end
-        // 2) thinkingLevel override: `-minimal` / `(minimal)` etc.
+        // 1) web search override: only `-search` at the end
+        // 2) streaming override: only `-real` / `-fake` at the end
+        // 3) thinkingLevel override: `-minimal` / `(minimal)` etc.
         const rawModel = responseBody.model || "gemini-2.5-flash-lite";
+        const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
+            FormatConverter.parseModelWebSearchSuffix(rawModel);
         const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
-            FormatConverter.parseModelStreamingModeSuffix(rawModel);
+            FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
         const { cleanModelName, thinkingLevel: modelThinkingLevel } =
             FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
+        if (modelForceWebSearch) {
+            this.logger.info(
+                `[Adapter] Detected webSearch suffix in model name: "${rawModel}" -> model="${searchStrippedModel}", forceWebSearch=true`
+            );
+        }
         if (modelStreamingMode) {
             this.logger.info(
-                `[Adapter] Detected streamingMode suffix in model name: "${rawModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                `[Adapter] Detected streamingMode suffix in model name: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
             );
         }
         if (modelThinkingLevel) {
@@ -3098,8 +3171,10 @@ class FormatConverter {
                 if (!googleRequest.tools) {
                     googleRequest.tools = [];
                 }
-                googleRequest.tools.push({ googleSearch: {} });
-                this.logger.info("[Adapter] Added googleSearch tool for OpenAI Response API web_search_preview");
+                if (!FormatConverter.hasGeminiGoogleSearchTool(googleRequest.tools)) {
+                    googleRequest.tools.push({ googleSearch: {} });
+                    this.logger.info("[Adapter] Added googleSearch tool for OpenAI Response API web_search_preview");
+                }
             }
         }
 
@@ -3109,11 +3184,7 @@ class FormatConverter {
 
             const ensureGoogleSearchTool = () => {
                 if (!googleRequest.tools) googleRequest.tools = [];
-                if (
-                    !googleRequest.tools.some(
-                        t => t && typeof t === "object" && Object.prototype.hasOwnProperty.call(t, "googleSearch")
-                    )
-                ) {
+                if (!FormatConverter.hasGeminiGoogleSearchTool(googleRequest.tools)) {
                     googleRequest.tools.push({ googleSearch: {} });
                 }
             };
@@ -3227,7 +3298,7 @@ class FormatConverter {
             }
         }
 
-        this._finalizeGoogleRequest(googleRequest);
+        this._finalizeGoogleRequest(googleRequest, { forceWebSearch: modelForceWebSearch });
         this.logger.info("[Adapter] OpenAI Response API to Google translation complete.");
         return { cleanModelName, googleRequest, modelStreamingMode };
     }

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -3543,13 +3543,14 @@ class RequestHandler {
 
         this.logger.debug(`[Proxy] Debug: incoming Gemini Body (Google Native) = ${JSON.stringify(bodyObj, null, 2)}`);
 
-        // Parse thinkingLevel suffix from model name in native Gemini generation requests
+        // Parse model suffixes from model name in native Gemini generation requests
         // Only handle generation requests: /v1beta/models/{modelName}:generateContent or :streamGenerateContent
         const modelPathMatch = cleanPath.match(
             /^(\/v1beta\/models\/)([^:]+)(:(generateContent|streamGenerateContent).*)$/
         );
         let modelThinkingLevel = null;
         let modelStreamingMode = null;
+        let modelForceWebSearch = false;
 
         if (modelPathMatch) {
             const pathPrefix = modelPathMatch[1];
@@ -3557,16 +3558,25 @@ class RequestHandler {
             const pathSuffix = modelPathMatch[3];
 
             const FormatConverter = require("./FormatConverter");
+            const { cleanModelName: searchStrippedModel, forceWebSearch: parsedForceWebSearch } =
+                FormatConverter.parseModelWebSearchSuffix(rawModelName);
             const { cleanModelName: streamStrippedModel, streamingMode: parsedStreamingMode } =
-                FormatConverter.parseModelStreamingModeSuffix(rawModelName);
+                FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
             const { cleanModelName, thinkingLevel: parsedThinkingLevel } =
                 FormatConverter.parseModelThinkingLevel(streamStrippedModel);
+            modelForceWebSearch = parsedForceWebSearch;
             modelStreamingMode = parsedStreamingMode;
             modelThinkingLevel = parsedThinkingLevel;
 
+            if (modelForceWebSearch) {
+                this.logger.info(
+                    `[Proxy] Detected webSearch suffix in model path: "${rawModelName}" -> model="${searchStrippedModel}", forceWebSearch=true`
+                );
+            }
+
             if (modelStreamingMode) {
                 this.logger.info(
-                    `[Proxy] Detected streamingMode suffix in model path: "${rawModelName}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                    `[Proxy] Detected streamingMode suffix in model path: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
                 );
             }
 
@@ -3629,7 +3639,7 @@ class RequestHandler {
 
         // Force web search and URL context for native Google requests
         if (
-            (this.serverSystem.forceWebSearch || this.serverSystem.forceUrlContext) &&
+            (this.serverSystem.forceWebSearch || modelForceWebSearch || this.serverSystem.forceUrlContext) &&
             req.method === "POST" &&
             bodyObj &&
             bodyObj.contents
@@ -3641,8 +3651,8 @@ class RequestHandler {
             const toolsToAdd = [];
 
             // Handle Google Search
-            if (this.serverSystem.forceWebSearch) {
-                const hasSearch = bodyObj.tools.some(t => t.googleSearch);
+            if (this.serverSystem.forceWebSearch || modelForceWebSearch) {
+                const hasSearch = FormatConverter.hasGeminiGoogleSearchTool(bodyObj.tools);
                 if (!hasSearch) {
                     bodyObj.tools.push({ googleSearch: {} });
                     toolsToAdd.push("googleSearch");
@@ -3655,7 +3665,7 @@ class RequestHandler {
 
             // Handle URL Context
             if (this.serverSystem.forceUrlContext) {
-                const hasUrlContext = bodyObj.tools.some(t => t.urlContext);
+                const hasUrlContext = FormatConverter.hasGeminiUrlContextTool(bodyObj.tools);
                 if (!hasUrlContext) {
                     bodyObj.tools.push({ urlContext: {} });
                     toolsToAdd.push("urlContext");

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -3557,7 +3557,6 @@ class RequestHandler {
             const rawModelName = modelPathMatch[2];
             const pathSuffix = modelPathMatch[3];
 
-            const FormatConverter = require("./FormatConverter");
             const { cleanModelName: searchStrippedModel, forceWebSearch: parsedForceWebSearch } =
                 FormatConverter.parseModelWebSearchSuffix(rawModelName);
             const { cleanModelName: streamStrippedModel, streamingMode: parsedStreamingMode } =


### PR DESCRIPTION
模型名后缀 `-search`，单独开启联网搜索

- fix #122 