### PR TITLE
feat: automate auth setup and batch account import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,28 @@
    npm run setup-auth
    ```
 
+   无交互模式示例：
+
+   ```bash
+   npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --headless
+   ```
+
+   如果账号启用了基于 TOTP 的 2FA，也可以在开始时直接带上密钥：
+
+   ```bash
+   npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --totp-secret your-base32-secret --headless
+   ```
+
+   如果您已经配置了 `users.csv`，也可以直接选择其中一个账号而不进入交互：
+
+   ```bash
+   npm run setup-auth -- --non-interactive --account 1
+   ```
+
    该脚本将：
    - 自动下载 Camoufox 浏览器（一个注重隐私的 Firefox 分支）
    - 启动浏览器并自动导航到 AI Studio
+   - 首次进入 AI Studio 时，尽量自动点击协议确认弹窗
    - 在本地保存您的身份验证凭据（auth 文件位于 `/configs/auth`）
 
    > 💡 **提示：** 如果下载 Camoufox 浏览器失败或等待太久，可以自行点击 [此处](https://github.com/daijro/camoufox/releases/tag/v135.0.1-beta.24) 下载，然后设置环境变量 `CAMOUFOX_EXECUTABLE_PATH` 为可执行文件的路径（支持绝对和相对路径）。
@@ -287,6 +306,8 @@ services:
 3. 运行 `npm run setup-auth` 后按提示选择账号。
 
 > 📖 详细配置说明请参阅：[账号自动填充指南](docs/zh/auto-fill-guide.md)
+>
+> 💡 **提示**：如果需要无交互执行，可使用 `npm run setup-auth -- --non-interactive --account 1`，或直接传入 `--email` / `--password`。
 
 ### 🧠 模型列表配置
 

--- a/README.md
+++ b/README.md
@@ -302,12 +302,14 @@ services:
 为了简化多个账号的登录流程，您可以通过配置 `users.csv` 文件来实现自动填充：
 
 1. 在项目根目录创建 `users.csv`。
-2. 格式为：`email,password`（每行一个）。
+2. 格式为：`email,password,totp_secret`（每行一个，`totp_secret` 可选）。
 3. 运行 `npm run setup-auth` 后按提示选择账号。
 
 > 📖 详细配置说明请参阅：[账号自动填充指南](docs/zh/auto-fill-guide.md)
 >
 > 💡 **提示**：如果需要无交互执行，可使用 `npm run setup-auth -- --non-interactive --account 1`，或直接传入 `--email` / `--password`。
+>
+> 💡 **批量添加**：使用 `npm run setup-auth-batch -- --headless` 可按顺序添加 `users.csv` 中的全部账号。
 
 ### 🧠 模型列表配置
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ services:
 为了简化多个账号的登录流程，您可以通过配置 `users.csv` 文件来实现自动填充：
 
 1. 在项目根目录创建 `users.csv`。
-2. 格式为：`email,password,totp_secret`（每行一个，`totp_secret` 可选）。
+2. 格式为：`email,password,recovery_email,totp_secret`（每行一个，`recovery_email` 和 `totp_secret` 可选）。
 3. 运行 `npm run setup-auth` 后按提示选择账号。
 
 > 📖 详细配置说明请参阅：[账号自动填充指南](docs/zh/auto-fill-guide.md)

--- a/README_EN.md
+++ b/README_EN.md
@@ -30,9 +30,28 @@ A tool that wraps Google AI Studio web interface to provide OpenAI API, Gemini A
    npm run setup-auth
    ```
 
+   Non-interactive example:
+
+   ```bash
+   npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --headless
+   ```
+
+   If the account uses TOTP-based 2FA, you can also provide the secret up front:
+
+   ```bash
+   npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --totp-secret your-base32-secret --headless
+   ```
+
+   If you already configured `users.csv`, you can also select an account without prompts:
+
+   ```bash
+   npm run setup-auth -- --non-interactive --account 1
+   ```
+
    This script will:
    - Automatically download the Camoufox browser (a privacy-focused Firefox fork)
    - Launch the browser and navigate to AI Studio automatically
+   - Try to auto-accept the first-run AI Studio agreement dialog when it appears
    - Save your authentication credentials locally (auth files are stored in `/configs/auth`)
 
    > 💡 **Tip:** If downloading the Camoufox browser fails or takes too long, you can manually download it from [here](https://github.com/daijro/camoufox/releases/tag/v135.0.1-beta.24), and set the environment variable `CAMOUFOX_EXECUTABLE_PATH` to the path of the browser executable (both absolute and relative paths are supported).
@@ -285,6 +304,8 @@ To simplify the login process for multiple accounts, you can configure the `user
 3. Run `npm run setup-auth` and select the account when prompted.
 
 > 📖 For detailed configuration instructions, see: [Account Auto-fill Guide](docs/en/auto-fill-guide.md)
+>
+> 💡 **Tip**: For promptless runs, use `npm run setup-auth -- --non-interactive --account 1`, or pass `--email` / `--password` directly.
 
 ### 🧠 Model List Configuration
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -300,7 +300,7 @@ Usage:
 To simplify the login process for multiple accounts, you can configure the `users.csv` file for auto-fill:
 
 1. Create `users.csv` in the project root.
-2. Format: `email,password,totp_secret` (one per line, `totp_secret` is optional).
+2. Format: `email,password,recovery_email,totp_secret` (one per line, `recovery_email` and `totp_secret` are optional).
 3. Run `npm run setup-auth` and select the account when prompted.
 
 > 📖 For detailed configuration instructions, see: [Account Auto-fill Guide](docs/en/auto-fill-guide.md)

--- a/README_EN.md
+++ b/README_EN.md
@@ -300,12 +300,14 @@ Usage:
 To simplify the login process for multiple accounts, you can configure the `users.csv` file for auto-fill:
 
 1. Create `users.csv` in the project root.
-2. Format: `email,password` (one per line).
+2. Format: `email,password,totp_secret` (one per line, `totp_secret` is optional).
 3. Run `npm run setup-auth` and select the account when prompted.
 
 > 📖 For detailed configuration instructions, see: [Account Auto-fill Guide](docs/en/auto-fill-guide.md)
 >
 > 💡 **Tip**: For promptless runs, use `npm run setup-auth -- --non-interactive --account 1`, or pass `--email` / `--password` directly.
+>
+> 💡 **Batch add**: Use `npm run setup-auth-batch -- --headless` to add every account in `users.csv` sequentially.
 
 ### 🧠 Model List Configuration
 

--- a/docs/en/auto-fill-guide.md
+++ b/docs/en/auto-fill-guide.md
@@ -24,7 +24,29 @@ npm run setup-auth
 
 When prompted in the terminal, select the account you want to use. The script will automatically open the browser and fill in the selected account's credentials.
 
+For promptless execution, you can select an account directly:
+
+```bash
+npm run setup-auth -- --non-interactive --account 1
+```
+
+Or pass the credentials explicitly:
+
+```bash
+npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --headless
+```
+
+If the account uses TOTP-based 2FA, you can append `--totp-secret`:
+
+```bash
+npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --totp-secret your-base32-secret --headless
+```
+
+In non-interactive mode, the script exits with a non-zero status if AI Studio login is not detected before timeout. Use `--login-timeout-ms` to adjust the timeout.
+
 ### 3. Considerations
 
 - **Security**: The `users.csv` file contains plain-text passwords; ensure your computer is secure and do not share this file.
-- **2FA**: If your account has Two-Factor Authentication (2FA) enabled, you will still need to complete the verification manually in the browser.
+- **First-run agreement**: When a new account enters AI Studio for the first time and a terms dialog appears, the script tries to tick visible checkboxes and click buttons such as `I agree`, `Agree`, `Continue`, or their Chinese equivalents.
+- **2FA**: For accounts with Two-Factor Authentication (2FA), standard TOTP can be auto-filled with `--totp-secret`; other challenge types still need to be completed manually in the browser.
+- **TOTP limitation**: `--totp-secret` only applies to standard TOTP apps such as Google Authenticator or Aegis. It does not cover SMS codes, Google Prompt, passkeys, or CAPTCHAs.

--- a/docs/en/auto-fill-guide.md
+++ b/docs/en/auto-fill-guide.md
@@ -7,12 +7,12 @@ Using a `users.csv` file significantly simplifies the Google login process.
 Create a `users.csv` file in the project root and add your account credentials in the following format:
 
 ```csv
-email,password,totp_secret
-your-email-1@gmail.com,your-password-1,BASE32TOTPSECRET1
-your-email-2@gmail.com,your-password-2,
+email,password,recovery_email,totp_secret
+your-email-1@gmail.com,your-password-1,recovery-1@example.com,BASE32TOTPSECRET1
+your-email-2@gmail.com,your-password-2,,
 ```
 
-> 💡 **Tip**: The header in the first line is optional. The script automatically identifies the column containing the `@` symbol as the account. `totp_secret` is optional and only applies to standard TOTP 2FA.
+> 💡 **Tip**: The header in the first line is optional. The script automatically identifies the column containing the `@` symbol as the account. `recovery_email` is used for Google's recovery email challenge, and `totp_secret` only applies to standard TOTP 2FA.
 
 ### 2. Start Login
 
@@ -60,5 +60,6 @@ In non-interactive mode, the script exits with a non-zero status if AI Studio lo
 
 - **Security**: The `users.csv` file contains plain-text passwords; ensure your computer is secure and do not share this file.
 - **First-run agreement**: When a new account enters AI Studio for the first time and a terms dialog appears, the script tries to tick visible checkboxes and click buttons such as `I agree`, `Agree`, `Continue`, or their Chinese equivalents.
-- **2FA**: For accounts with Two-Factor Authentication (2FA), standard TOTP can be auto-filled with `--totp-secret`; other challenge types still need to be completed manually in the browser.
+- **Recovery email**: If Google asks to confirm the recovery email, the script uses `recovery_email` from `users.csv`, or the value passed via `--recovery-email`.
+- **2FA**: For accounts with Two-Factor Authentication (2FA), standard TOTP can be auto-filled with `--totp-secret`; recovery email confirmation can also be auto-filled, while other challenge types still need to be completed manually in the browser.
 - **TOTP limitation**: `--totp-secret` only applies to standard TOTP apps such as Google Authenticator or Aegis. It does not cover SMS codes, Google Prompt, passkeys, or CAPTCHAs.

--- a/docs/en/auto-fill-guide.md
+++ b/docs/en/auto-fill-guide.md
@@ -7,12 +7,12 @@ Using a `users.csv` file significantly simplifies the Google login process.
 Create a `users.csv` file in the project root and add your account credentials in the following format:
 
 ```csv
-email,password
-your-email-1@gmail.com,your-password-1
-your-email-2@gmail.com,your-password-2
+email,password,totp_secret
+your-email-1@gmail.com,your-password-1,BASE32TOTPSECRET1
+your-email-2@gmail.com,your-password-2,
 ```
 
-> 💡 **Tip**: The header in the first line (`email,password`) is optional. The script automatically identifies the column containing the `@` symbol as the account.
+> 💡 **Tip**: The header in the first line is optional. The script automatically identifies the column containing the `@` symbol as the account. `totp_secret` is optional and only applies to standard TOTP 2FA.
 
 ### 2. Start Login
 
@@ -40,6 +40,18 @@ If the account uses TOTP-based 2FA, you can append `--totp-secret`:
 
 ```bash
 npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --totp-secret your-base32-secret --headless
+```
+
+To add every account in `users.csv` in batch:
+
+```bash
+npm run setup-auth-batch -- --headless
+```
+
+You can also process only part of the list and continue with remaining accounts after one account fails:
+
+```bash
+npm run setup-auth-batch -- --accounts 1,3-5 --headless --continue-on-error
 ```
 
 In non-interactive mode, the script exits with a non-zero status if AI Studio login is not detected before timeout. Use `--login-timeout-ms` to adjust the timeout.

--- a/docs/zh/auto-fill-guide.md
+++ b/docs/zh/auto-fill-guide.md
@@ -7,12 +7,12 @@
 在项目根目录创建 `users.csv`，按以下格式添加账号密码：
 
 ```csv
-email,password
-your-email-1@gmail.com,your-password-1
-your-email-2@gmail.com,your-password-2
+email,password,totp_secret
+your-email-1@gmail.com,your-password-1,BASE32TOTPSECRET1
+your-email-2@gmail.com,your-password-2,
 ```
 
-> 💡 **提示**：第一行的表头（`email,password`）是可选的，脚本会自动识别包含 `@` 符号的列作为账号。
+> 💡 **提示**：第一行的表头是可选的，脚本会自动识别包含 `@` 符号的列作为账号。`totp_secret` 也是可选列，只用于标准 TOTP 2FA。
 
 ### 2. 开始登录
 
@@ -40,6 +40,18 @@ npm run setup-auth -- --non-interactive --email your-email@gmail.com --password 
 
 ```bash
 npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --totp-secret your-base32-secret --headless
+```
+
+如果要批量添加 `users.csv` 中的全部账号：
+
+```bash
+npm run setup-auth-batch -- --headless
+```
+
+也可以只处理部分账号，并在某个账号失败后继续处理剩余账号：
+
+```bash
+npm run setup-auth-batch -- --accounts 1,3-5 --headless --continue-on-error
 ```
 
 无交互模式下，如果在超时时间内未检测到 AI Studio 登录成功，脚本会直接退出并返回非 0 状态码。可通过 `--login-timeout-ms` 调整超时时间。

--- a/docs/zh/auto-fill-guide.md
+++ b/docs/zh/auto-fill-guide.md
@@ -24,7 +24,29 @@ npm run setup-auth
 
 在控制台中，根据提示选择要使用的账号即可。脚本将自动打开浏览器并填入所选账号的凭据。
 
+如果需要无交互执行，可以直接指定账号：
+
+```bash
+npm run setup-auth -- --non-interactive --account 1
+```
+
+或者直接传入账号密码：
+
+```bash
+npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --headless
+```
+
+如果账号启用了基于 TOTP 的 2FA，可以追加 `--totp-secret`：
+
+```bash
+npm run setup-auth -- --non-interactive --email your-email@gmail.com --password your-password --totp-secret your-base32-secret --headless
+```
+
+无交互模式下，如果在超时时间内未检测到 AI Studio 登录成功，脚本会直接退出并返回非 0 状态码。可通过 `--login-timeout-ms` 调整超时时间。
+
 ### 3. 注意事项
 
 - **安全**：`users.csv` 包含明文密码，请确保您的计算机安全且不要分享该文件。
-- **2FA**：如果账号启用了双重身份验证（2FA），您仍需在浏览器中手动完成验证。
+- **首次协议**：新账号首次进入 AI Studio 时，如果出现协议弹窗，脚本会尝试自动勾选复选框并点击 `I agree` / `同意` / `继续` 等按钮。
+- **2FA**：如果账号启用了双重身份验证（2FA），标准 TOTP 可以通过 `--totp-secret` 自动填写；其他方式仍需在浏览器中手动完成。
+- **TOTP 限制**：`--totp-secret` 只适用于标准 TOTP（例如 Google Authenticator / Aegis），不适用于短信验证码、Google Prompt、Passkey 或图形验证码。

--- a/docs/zh/auto-fill-guide.md
+++ b/docs/zh/auto-fill-guide.md
@@ -7,12 +7,12 @@
 在项目根目录创建 `users.csv`，按以下格式添加账号密码：
 
 ```csv
-email,password,totp_secret
-your-email-1@gmail.com,your-password-1,BASE32TOTPSECRET1
-your-email-2@gmail.com,your-password-2,
+email,password,recovery_email,totp_secret
+your-email-1@gmail.com,your-password-1,recovery-1@example.com,BASE32TOTPSECRET1
+your-email-2@gmail.com,your-password-2,,
 ```
 
-> 💡 **提示**：第一行的表头是可选的，脚本会自动识别包含 `@` 符号的列作为账号。`totp_secret` 也是可选列，只用于标准 TOTP 2FA。
+> 💡 **提示**：第一行的表头是可选的，脚本会自动识别包含 `@` 符号的列作为账号。`recovery_email` 用于 Google 的恢复邮箱确认，`totp_secret` 只用于标准 TOTP 2FA。
 
 ### 2. 开始登录
 
@@ -60,5 +60,6 @@ npm run setup-auth-batch -- --accounts 1,3-5 --headless --continue-on-error
 
 - **安全**：`users.csv` 包含明文密码，请确保您的计算机安全且不要分享该文件。
 - **首次协议**：新账号首次进入 AI Studio 时，如果出现协议弹窗，脚本会尝试自动勾选复选框并点击 `I agree` / `同意` / `继续` 等按钮。
-- **2FA**：如果账号启用了双重身份验证（2FA），标准 TOTP 可以通过 `--totp-secret` 自动填写；其他方式仍需在浏览器中手动完成。
+- **恢复邮箱**：如果 Google 要求确认恢复邮箱，脚本会优先使用 `users.csv` 中的 `recovery_email`，也可通过 `--recovery-email` 指定。
+- **2FA**：如果账号启用了双重身份验证（2FA），标准 TOTP 可以通过 `--totp-secret` 自动填写；恢复邮箱确认可自动填写，其他方式仍需在浏览器中手动完成。
 - **TOTP 限制**：`--totp-secret` 只适用于标准 TOTP（例如 Google Authenticator / Aegis），不适用于短信验证码、Google Prompt、Passkey 或图形验证码。

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "prestart": "npm run build:ui",
         "save-auth": "node scripts/auth/saveAuth.js",
         "setup-auth": "node scripts/auth/setupAuth.js",
+        "setup-auth-batch": "node scripts/auth/setupAuthBatch.js",
         "prepare": "husky install",
         "lint": "eslint . && stylelint \"ui/**/*.{css,less}\"",
         "lint:fix": "eslint . --fix && stylelint \"ui/**/*.{css,less}\" --fix",

--- a/scripts/auth/saveAuth.js
+++ b/scripts/auth/saveAuth.js
@@ -110,6 +110,15 @@ const parseCliArgs = args => {
             i++;
             continue;
         }
+        if (arg.startsWith("--recovery-email=")) {
+            options.recoveryEmail = arg.slice("--recovery-email=".length);
+            continue;
+        }
+        if (arg === "--recovery-email") {
+            options.recoveryEmail = readRequiredOptionValue(args, i, "--recovery-email");
+            i++;
+            continue;
+        }
         if (arg.startsWith("--totp-secret=")) {
             options.totpSecret = arg.slice("--totp-secret=".length);
             continue;
@@ -144,6 +153,7 @@ const printHelp = () => {
     console.log("  --lang <zh|en>             Override output language");
     console.log("  --email <email>            Auto-fill the Google account email");
     console.log("  --password <password>      Auto-fill the Google account password");
+    console.log("  --recovery-email <email>   Auto-fill Google recovery email challenge");
     console.log("  --totp-secret <secret>     Auto-fill Google TOTP 2FA code using a Base32 secret");
     console.log("  --headless                 Launch Camoufox in headless mode");
     console.log("  --headed                   Force headed mode");
@@ -158,6 +168,7 @@ const printHelp = () => {
     console.log("  SETUP_AUTH_DEBUG_UI=true");
     console.log("  AUTO_FILL_EMAIL=<email>");
     console.log("  AUTO_FILL_PWD=<password>");
+    console.log("  SETUP_AUTH_RECOVERY_EMAIL=<recovery email>");
     console.log("  SETUP_AUTH_TOTP_SECRET=<base32 secret>");
     console.log("  CAMOUFOX_EXECUTABLE_PATH=<path to camoufox executable>");
 };
@@ -180,6 +191,7 @@ const runtimeOptions = {
     lang: normalizeLanguage(cliOptions.lang ?? process.env.SETUP_AUTH_LANG),
     loginTimeoutMs,
     nonInteractive: cliOptions.nonInteractive ?? parseBooleanLike(process.env.SETUP_AUTH_NON_INTERACTIVE) ?? false,
+    recoveryEmail: cliOptions.recoveryEmail ?? process.env.SETUP_AUTH_RECOVERY_EMAIL,
     totpSecret: cliOptions.totpSecret ?? process.env.SETUP_AUTH_TOTP_SECRET,
 };
 lang = runtimeOptions.lang;
@@ -674,10 +686,11 @@ const fillTotpInputs = async (page, code) => {
     return false;
 };
 
-const autoFillTotpIfRequired = async (page, totpSecret, randomWait) => {
+const autoFillTotpIfRequired = async (page, totpSecret, randomWait, options = {}) => {
     if (!totpSecret) return false;
 
-    for (let attempt = 0; attempt < 20; attempt++) {
+    const maxAttempts = options.maxAttempts ?? 20;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
         try {
             const title = await page.title();
             if (title.includes("AI Studio")) return false;
@@ -703,6 +716,123 @@ const autoFillTotpIfRequired = async (page, totpSecret, randomWait) => {
             return true;
         }
 
+        await page.waitForTimeout(1000);
+    }
+
+    return false;
+};
+
+const clickRecoveryEmailOption = async (page, randomWait) => {
+    const optionPatterns = [
+        /confirm your recovery email/i,
+        /confirm.*recovery email/i,
+        /verify.*recovery email/i,
+        /确认.*辅助邮箱/,
+        /确认.*恢复邮箱/,
+        /验证.*辅助邮箱/,
+        /验证.*恢复邮箱/,
+    ];
+    const controlSelector = 'button, [role="button"], [role="link"], div[role="link"], div[role="button"]';
+
+    for (const frame of page.frames()) {
+        const controls = frame.locator(controlSelector);
+        const controlCount = await controls.count().catch(() => 0);
+        for (let i = 0; i < Math.min(controlCount, 40); i++) {
+            const control = controls.nth(i);
+            try {
+                if (!(await control.isVisible({ timeout: 150 }))) continue;
+                const text = ((await control.textContent({ timeout: 300 }).catch(() => "")) || "")
+                    .replace(/\s+/g, " ")
+                    .trim();
+                const ariaLabel = ((await control.getAttribute("aria-label").catch(() => "")) || "").trim();
+                const label = text || ariaLabel;
+                if (!optionPatterns.some(pattern => pattern.test(label))) continue;
+
+                console.log(
+                    getText(
+                        "🕵️ 检测到恢复邮箱确认选项，正在选择该验证方式...",
+                        "🕵️ Detected the recovery email verification option. Selecting it..."
+                    )
+                );
+                await control.scrollIntoViewIfNeeded().catch(() => {});
+                await control.click({ timeout: 5000 });
+                await randomWait();
+                return true;
+            } catch {
+                // Continue scanning other candidates.
+            }
+        }
+    }
+
+    return false;
+};
+
+const fillRecoveryEmailInput = async (page, recoveryEmail) => {
+    const challengePattern =
+        /confirm your recovery email|enter your recovery email|recovery email|辅助邮箱|恢复邮箱|备用邮箱|找回邮箱/i;
+    const inputSelector = [
+        'input[name="knowledgePreregisteredEmailResponse"]',
+        'input[type="email"]',
+        'input[aria-label*="recovery" i]',
+        'input[aria-label*="email" i]',
+        'input[aria-label*="邮箱"]',
+        'input[placeholder*="recovery" i]',
+        'input[placeholder*="email" i]',
+        'input[placeholder*="邮箱"]',
+        'input[type="text"]',
+    ].join(", ");
+
+    for (const frame of page.frames()) {
+        let bodyText = "";
+        try {
+            bodyText = (await frame.locator("body").textContent({ timeout: 500 })) || "";
+        } catch {
+            // Frame may still be navigating.
+        }
+        if (!challengePattern.test(bodyText)) continue;
+
+        const inputs = frame.locator(inputSelector);
+        const inputCount = await inputs.count().catch(() => 0);
+        for (let i = 0; i < Math.min(inputCount, 8); i++) {
+            const input = inputs.nth(i);
+            try {
+                if ((await input.isVisible({ timeout: 250 })) && (await input.isEditable())) {
+                    await input.fill(recoveryEmail);
+                    return true;
+                }
+            } catch {
+                // Ignore non-editable or detached candidates.
+            }
+        }
+    }
+
+    return false;
+};
+
+const autoFillRecoveryEmailIfRequired = async (page, recoveryEmail, randomWait) => {
+    if (!recoveryEmail) return false;
+
+    for (let attempt = 0; attempt < 20; attempt++) {
+        try {
+            const title = await page.title();
+            if (title.includes("AI Studio")) return false;
+        } catch {
+            // Page may still be navigating.
+        }
+
+        const filled = await fillRecoveryEmailInput(page, recoveryEmail);
+        if (filled) {
+            console.log(
+                getText("🕵️ 已自动填入恢复邮箱验证。", "🕵️ Auto-filled the recovery email verification challenge.")
+            );
+            await randomWait();
+            await page.keyboard.press("Enter");
+            await randomWait();
+            await clickGoogleTransitionButtons(page, randomWait);
+            return true;
+        }
+
+        await clickRecoveryEmailOption(page, randomWait);
         await page.waitForTimeout(1000);
     }
 
@@ -860,7 +990,10 @@ const autoFillTotpIfRequired = async (page, totpSecret, randomWait) => {
 
                 try {
                     await acceptAiStudioTermsIfPresent(page, randomWait, { rounds: 4 });
-                    await autoFillTotpIfRequired(page, runtimeOptions.totpSecret, randomWait);
+                    await autoFillTotpIfRequired(page, runtimeOptions.totpSecret, randomWait, {
+                        maxAttempts: runtimeOptions.recoveryEmail ? 8 : 20,
+                    });
+                    await autoFillRecoveryEmailIfRequired(page, runtimeOptions.recoveryEmail, randomWait);
                     await acceptAiStudioTermsIfPresent(page, randomWait, { rounds: 4 });
                     await clickGoogleTransitionButtons(page, randomWait);
                 } catch (e) {

--- a/scripts/auth/saveAuth.js
+++ b/scripts/auth/saveAuth.js
@@ -920,6 +920,7 @@ const autoFillTotpIfRequired = async (page, totpSecret, randomWait) => {
 
     if (!loginDetected) {
         if (runtimeOptions.nonInteractive) {
+            await logAuthUiDiagnostics(page, "登录超时前未检测到 AI Studio 标题");
             console.error(
                 getText(
                     `❌ 在 ${maxWaitTime}ms 内未检测到 AI Studio 登录成功，已退出无交互模式。`,

--- a/scripts/auth/saveAuth.js
+++ b/scripts/auth/saveAuth.js
@@ -6,6 +6,7 @@
  */
 
 const { firefox } = require("playwright");
+const crypto = require("crypto");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
@@ -14,10 +15,174 @@ const path = require("path");
 require("dotenv").config({ path: path.resolve(__dirname, "..", "..", ".env") });
 
 // Initialize language from environment variable passed by setupAuth.js
-const lang = process.env.SETUP_AUTH_LANG || "zh";
+const normalizeLanguage = value => {
+    const normalized = String(value || "")
+        .trim()
+        .toLowerCase();
+    if (normalized === "2" || normalized === "en" || normalized === "english") {
+        return "en";
+    }
+    return "zh";
+};
+
+let lang = normalizeLanguage(process.env.SETUP_AUTH_LANG || "zh");
 
 // Bilingual text helper
 const getText = (zh, en) => (lang === "zh" ? zh : en);
+
+const parseBooleanLike = value => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const normalized = String(value).trim().toLowerCase();
+    if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+    return undefined;
+};
+
+const parsePositiveInteger = (value, optionName) => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const parsed = Number.parseInt(String(value), 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(getText(`${optionName} 必须是正整数。`, `${optionName} must be a positive integer.`));
+    }
+    return parsed;
+};
+
+const readRequiredOptionValue = (args, index, optionName) => {
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("-")) {
+        throw new Error(getText(`缺少 ${optionName} 的值。`, `Missing value for ${optionName}.`));
+    }
+    return value;
+};
+
+const parseCliArgs = args => {
+    const options = {
+        headless: undefined,
+        nonInteractive: undefined,
+    };
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === "-h" || arg === "--help") {
+            options.help = true;
+            continue;
+        }
+        if (arg === "--non-interactive") {
+            options.nonInteractive = true;
+            continue;
+        }
+        if (arg === "--headless") {
+            options.headless = true;
+            continue;
+        }
+        if (arg === "--headed") {
+            options.headless = false;
+            continue;
+        }
+        if (arg === "--debug-ui") {
+            options.debugUi = true;
+            continue;
+        }
+        if (arg.startsWith("--lang=")) {
+            options.lang = arg.slice("--lang=".length);
+            continue;
+        }
+        if (arg === "--lang") {
+            options.lang = readRequiredOptionValue(args, i, "--lang");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--email=")) {
+            options.email = arg.slice("--email=".length);
+            continue;
+        }
+        if (arg === "--email") {
+            options.email = readRequiredOptionValue(args, i, "--email");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--password=")) {
+            options.password = arg.slice("--password=".length);
+            continue;
+        }
+        if (arg === "--password") {
+            options.password = readRequiredOptionValue(args, i, "--password");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--totp-secret=")) {
+            options.totpSecret = arg.slice("--totp-secret=".length);
+            continue;
+        }
+        if (arg === "--totp-secret") {
+            options.totpSecret = readRequiredOptionValue(args, i, "--totp-secret");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--login-timeout-ms=")) {
+            options.loginTimeoutMs = arg.slice("--login-timeout-ms=".length);
+            continue;
+        }
+        if (arg === "--login-timeout-ms") {
+            options.loginTimeoutMs = readRequiredOptionValue(args, i, "--login-timeout-ms");
+            i++;
+            continue;
+        }
+
+        throw new Error(getText(`未知参数: ${arg}`, `Unknown argument: ${arg}`));
+    }
+
+    return options;
+};
+
+const printHelp = () => {
+    console.log("Usage: npm run save-auth -- [options]");
+    console.log("");
+    console.log("Options:");
+    console.log("  -h, --help                 Show this help message");
+    console.log("  --non-interactive          Exit on timeout/failure instead of waiting for Enter");
+    console.log("  --lang <zh|en>             Override output language");
+    console.log("  --email <email>            Auto-fill the Google account email");
+    console.log("  --password <password>      Auto-fill the Google account password");
+    console.log("  --totp-secret <secret>     Auto-fill Google TOTP 2FA code using a Base32 secret");
+    console.log("  --headless                 Launch Camoufox in headless mode");
+    console.log("  --headed                   Force headed mode");
+    console.log("  --login-timeout-ms <ms>    Override login detection timeout");
+    console.log("  --debug-ui                 Dump UI diagnostics before auth export");
+    console.log("");
+    console.log("Environment variables:");
+    console.log("  SETUP_AUTH_LANG=zh|en");
+    console.log("  SETUP_AUTH_NON_INTERACTIVE=true");
+    console.log("  SETUP_AUTH_HEADLESS=true");
+    console.log("  SETUP_AUTH_LOGIN_TIMEOUT_MS=300000");
+    console.log("  SETUP_AUTH_DEBUG_UI=true");
+    console.log("  AUTO_FILL_EMAIL=<email>");
+    console.log("  AUTO_FILL_PWD=<password>");
+    console.log("  SETUP_AUTH_TOTP_SECRET=<base32 secret>");
+    console.log("  CAMOUFOX_EXECUTABLE_PATH=<path to camoufox executable>");
+};
+
+const cliOptions = parseCliArgs(process.argv.slice(2));
+if (cliOptions.help) {
+    printHelp();
+    process.exit(0);
+}
+
+const loginTimeoutMs =
+    parsePositiveInteger(cliOptions.loginTimeoutMs ?? process.env.SETUP_AUTH_LOGIN_TIMEOUT_MS, "login-timeout-ms") ||
+    300000;
+
+const runtimeOptions = {
+    autoFillEmail: cliOptions.email ?? process.env.AUTO_FILL_EMAIL,
+    autoFillPwd: cliOptions.password ?? process.env.AUTO_FILL_PWD,
+    debugUi: cliOptions.debugUi ?? parseBooleanLike(process.env.SETUP_AUTH_DEBUG_UI) ?? false,
+    headless: cliOptions.headless ?? parseBooleanLike(process.env.SETUP_AUTH_HEADLESS) ?? false,
+    lang: normalizeLanguage(cliOptions.lang ?? process.env.SETUP_AUTH_LANG),
+    loginTimeoutMs,
+    nonInteractive: cliOptions.nonInteractive ?? parseBooleanLike(process.env.SETUP_AUTH_NON_INTERACTIVE) ?? false,
+    totpSecret: cliOptions.totpSecret ?? process.env.SETUP_AUTH_TOTP_SECRET,
+};
+lang = runtimeOptions.lang;
 
 // --- Configuration Constants ---
 const getDefaultBrowserExecutablePath = () => {
@@ -76,6 +241,474 @@ const getNextAuthIndex = () => {
     return Math.max(...indices) + 1;
 };
 
+const closeBrowserSafely = async browser => {
+    if (!browser) return;
+    try {
+        await browser.close();
+    } catch {
+        // ignore browser cleanup error
+    }
+};
+
+const normalizeTotpSecret = secret => {
+    const raw = String(secret || "").trim();
+    if (!raw) return "";
+
+    if (raw.startsWith("otpauth://")) {
+        try {
+            const otpUrl = new URL(raw);
+            const parsedSecret = otpUrl.searchParams.get("secret");
+            if (parsedSecret) return parsedSecret;
+        } catch {
+            // Fall back to treating the raw input as a plain secret.
+        }
+    }
+
+    return raw;
+};
+
+const decodeBase32Secret = secret => {
+    const sanitized = normalizeTotpSecret(secret)
+        .toUpperCase()
+        .replace(/\s+/g, "")
+        .replace(/-/g, "")
+        .replace(/=+$/g, "");
+
+    if (!sanitized) {
+        throw new Error(getText("TOTP 密钥为空。", "TOTP secret is empty."));
+    }
+
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+    let bits = 0;
+    let value = 0;
+    const bytes = [];
+
+    for (const char of sanitized) {
+        const index = alphabet.indexOf(char);
+        if (index === -1) {
+            throw new Error(
+                getText(`TOTP 密钥包含无效字符: ${char}`, `TOTP secret contains an invalid character: ${char}`)
+            );
+        }
+
+        value = (value << 5) | index;
+        bits += 5;
+
+        if (bits >= 8) {
+            bytes.push((value >>> (bits - 8)) & 255);
+            bits -= 8;
+        }
+    }
+
+    return Buffer.from(bytes);
+};
+
+const waitForFreshTotpWindow = async () => {
+    const secondsRemaining = 30 - (Math.floor(Date.now() / 1000) % 30);
+    if (secondsRemaining <= 3) {
+        await new Promise(resolve => setTimeout(resolve, (secondsRemaining + 1) * 1000));
+    }
+};
+
+const generateTotpCode = secret => {
+    const key = decodeBase32Secret(secret);
+    const counter = Math.floor(Date.now() / 1000 / 30);
+    const buffer = Buffer.alloc(8);
+
+    buffer.writeUInt32BE(Math.floor(counter / 0x100000000), 0);
+    buffer.writeUInt32BE(counter >>> 0, 4);
+
+    const hmac = crypto.createHmac("sha1", key).update(buffer).digest();
+    const offset = hmac[hmac.length - 1] & 15;
+    const code = (hmac.readUInt32BE(offset) & 0x7fffffff) % 1000000;
+    return String(code).padStart(6, "0");
+};
+
+const clickGoogleTransitionButtons = async (page, randomWait) => {
+    const nextButton = page.locator(
+        'button:has(span:text("Next")), button:has(span:text("下一步")), button:has-text("Next"), button:has-text("下一步")'
+    );
+    const notNowButton = page.locator(
+        'button:has(span:text("Not now")), button:has(span:text("暂时不")), button:has-text("Not now"), button:has-text("暂时不")'
+    );
+
+    for (let i = 0; i < 10; i++) {
+        if (await nextButton.isVisible({ timeout: 1000 })) {
+            console.log(
+                getText(
+                    "🕵️ 检测到「下一步」按钮，正在点击以跳过说明页...",
+                    "🕵️ Detected 'Next' button, clicking to skip info page..."
+                )
+            );
+            await nextButton.click();
+            await randomWait();
+        } else if (await notNowButton.isVisible({ timeout: 1000 })) {
+            console.log(
+                getText(
+                    "🕵️ 检测到「暂时不」按钮，正在点击以跳过...",
+                    "🕵️ Detected 'Not now' button, clicking to skip..."
+                )
+            );
+            await notNowButton.click();
+            await randomWait();
+        }
+
+        const title = await page.title();
+        if (title.includes("AI Studio")) break;
+        await page.waitForTimeout(1000);
+    }
+};
+
+const acceptAiStudioTermsIfPresent = async (page, randomWait, options = {}) => {
+    const maxRounds = options.rounds ?? 12;
+    const explicitAcceptPatterns = [/^i agree$/i, /^i accept$/i, /^agree$/i, /^accept$/i, /^(我同意|同意|接受)$/i];
+    const contextualButtonPatterns = [
+        /^continue$/i,
+        /^ok$/i,
+        /^okay$/i,
+        /^got it$/i,
+        /^(继续|确定|好的|知道了|完成)$/i,
+    ];
+    const checkboxSelector = 'input[type="checkbox"], [role="checkbox"]';
+    const agreementContainerSelector = [
+        '[role="dialog"]',
+        '[aria-modal="true"]',
+        "mat-dialog-container",
+        ".mat-mdc-dialog-container",
+        ".cdk-overlay-pane",
+        ".mdc-dialog",
+    ].join(", ");
+    const termsPattern =
+        /google api terms|terms of service|additional terms|privacy policy|\bterms\b|agree to|accept.*terms|条款|协议|政策|隐私|同意/i;
+
+    const normalizeControlText = value =>
+        String(value || "")
+            .replace(/\s+/g, " ")
+            .trim();
+
+    const getControlLabel = async control => {
+        const text = await control.textContent({ timeout: 300 }).catch(() => "");
+        const ariaLabel = await control.getAttribute("aria-label").catch(() => "");
+        const value = await control.getAttribute("value").catch(() => "");
+        return normalizeControlText(text || ariaLabel || value);
+    };
+
+    const clickAgreementControl = async control => {
+        try {
+            if (!(await control.isVisible({ timeout: 300 }))) return false;
+            if (await control.isDisabled().catch(() => false)) return false;
+            await control.scrollIntoViewIfNeeded().catch(() => {});
+            console.log(
+                getText(
+                    "🕵️ 检测到 AI Studio 首次协议弹窗，正在自动点击确认按钮...",
+                    "🕵️ Detected an AI Studio first-run agreement dialog. Clicking the confirmation button..."
+                )
+            );
+            await control.click({ timeout: 5000 });
+            await randomWait();
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    const ensureCheckboxChecked = async checkbox => {
+        try {
+            const role = await checkbox.getAttribute("role").catch(() => null);
+            const checked =
+                role === "checkbox"
+                    ? (await checkbox.getAttribute("aria-checked").catch(() => "")) === "true"
+                    : await checkbox.isChecked().catch(() => false);
+            if (!checked) {
+                await checkbox.scrollIntoViewIfNeeded().catch(() => {});
+                await checkbox.click({ timeout: 5000 });
+                await randomWait();
+            }
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    const clickMatchingButton = async (container, patterns) => {
+        for (const pattern of patterns) {
+            const button = container.getByRole("button", { name: pattern }).first();
+            if (await clickAgreementControl(button)) return true;
+        }
+
+        const controls = container.locator('button, [role="button"], input[type="button"], input[type="submit"]');
+        const controlCount = await controls.count().catch(() => 0);
+        for (let i = 0; i < Math.min(controlCount, 30); i++) {
+            const control = controls.nth(i);
+            const label = await getControlLabel(control);
+            if (!label || !patterns.some(pattern => pattern.test(label))) continue;
+            if (await clickAgreementControl(control)) return true;
+        }
+
+        return false;
+    };
+
+    const processContainer = async (container, fallbackText) => {
+        let containerText = fallbackText || "";
+        try {
+            containerText = (await container.textContent({ timeout: 500 })) || containerText;
+        } catch {
+            // Some containers may detach while the page is settling.
+        }
+
+        const looksLikeTerms = termsPattern.test(containerText);
+        const checkboxes = container.locator(checkboxSelector);
+        const checkboxCount = await checkboxes.count().catch(() => 0);
+
+        if (!looksLikeTerms && checkboxCount === 0) {
+            return clickMatchingButton(container, explicitAcceptPatterns);
+        }
+
+        for (let i = 0; i < Math.min(checkboxCount, 3); i++) {
+            const checkbox = checkboxes.nth(i);
+            try {
+                if (await checkbox.isVisible({ timeout: 200 })) {
+                    await ensureCheckboxChecked(checkbox);
+                }
+            } catch {
+                // Keep going if one checkbox becomes detached.
+            }
+        }
+
+        if (await clickMatchingButton(container, explicitAcceptPatterns)) return true;
+        return clickMatchingButton(container, contextualButtonPatterns);
+    };
+
+    for (let round = 0; round < maxRounds; round++) {
+        for (const frame of page.frames()) {
+            let bodyText = "";
+            try {
+                bodyText = (await frame.locator("body").textContent({ timeout: 500 })) || "";
+            } catch {
+                // Ignore detached/cross-origin frames and continue scanning others.
+            }
+
+            const containers = frame.locator(agreementContainerSelector);
+            const containerCount = await containers.count().catch(() => 0);
+            for (let i = 0; i < Math.min(containerCount, 6); i++) {
+                const container = containers.nth(i);
+                try {
+                    if (
+                        (await container.isVisible({ timeout: 200 })) &&
+                        (await processContainer(container, bodyText))
+                    ) {
+                        return true;
+                    }
+                } catch {
+                    // Continue scanning other containers.
+                }
+            }
+
+            try {
+                const body = frame.locator("body");
+                if (await processContainer(body, bodyText)) {
+                    return true;
+                }
+            } catch {
+                // Continue polling for the next round.
+            }
+        }
+
+        await page.waitForTimeout(1000);
+    }
+
+    return false;
+};
+
+const truncateDiagnosticText = (value, maxLength = 220) => {
+    const normalized = String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+    return normalized.length > maxLength ? `${normalized.slice(0, maxLength)}...` : normalized;
+};
+
+const logAuthUiDiagnostics = async (page, reason) => {
+    if (!runtimeOptions.debugUi) return;
+
+    console.log("");
+    console.log(getText(`🔎 UI 调试: ${reason}`, `🔎 UI debug: ${reason}`));
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const debugDir = path.join(__dirname, "..", "..", "logs");
+    const screenshotPath = path.join(debugDir, `auth-ui-${timestamp}.png`);
+    const htmlPath = path.join(debugDir, `auth-ui-${timestamp}.html`);
+
+    try {
+        fs.mkdirSync(debugDir, { recursive: true });
+        await page.screenshot({ fullPage: true, path: screenshotPath });
+        fs.writeFileSync(htmlPath, await page.content());
+        console.log(
+            getText(
+                `   -> 页面截图: ${path.relative(path.join(__dirname, "..", ".."), screenshotPath)}`,
+                `   -> Screenshot: ${path.relative(path.join(__dirname, "..", ".."), screenshotPath)}`
+            )
+        );
+        console.log(
+            getText(
+                `   -> 页面 HTML: ${path.relative(path.join(__dirname, "..", ".."), htmlPath)}`,
+                `   -> Page HTML: ${path.relative(path.join(__dirname, "..", ".."), htmlPath)}`
+            )
+        );
+    } catch (error) {
+        console.warn(
+            getText(
+                `   -> 保存 UI 调试文件失败: ${error.message}`,
+                `   -> Failed to save UI debug files: ${error.message}`
+            )
+        );
+    }
+
+    const dialogSelector = [
+        '[role="dialog"]',
+        '[aria-modal="true"]',
+        "mat-dialog-container",
+        ".mat-mdc-dialog-container",
+        ".cdk-overlay-pane",
+        ".mdc-dialog",
+    ].join(", ");
+    const controlSelector = 'button, [role="button"], input[type="button"], input[type="submit"]';
+    const checkboxSelector = 'input[type="checkbox"], [role="checkbox"]';
+
+    for (const [frameIndex, frame] of page.frames().entries()) {
+        console.log(`   -> frame #${frameIndex}: ${truncateDiagnosticText(frame.url(), 180)}`);
+
+        try {
+            const bodyText = await frame.locator("body").textContent({ timeout: 500 });
+            console.log(`      body: ${truncateDiagnosticText(bodyText, 320)}`);
+        } catch {
+            console.log("      body: <unavailable>");
+        }
+
+        const dialogs = frame.locator(dialogSelector);
+        const dialogCount = await dialogs.count().catch(() => 0);
+        for (let i = 0; i < Math.min(dialogCount, 8); i++) {
+            const dialog = dialogs.nth(i);
+            try {
+                if (await dialog.isVisible({ timeout: 200 })) {
+                    const text = await dialog.textContent({ timeout: 500 }).catch(() => "");
+                    console.log(`      dialog[${i}]: ${truncateDiagnosticText(text, 320)}`);
+                }
+            } catch {
+                // Ignore detached diagnostics candidates.
+            }
+        }
+
+        const checkboxes = frame.locator(checkboxSelector);
+        const checkboxCount = await checkboxes.count().catch(() => 0);
+        let visibleCheckboxes = 0;
+        for (let i = 0; i < Math.min(checkboxCount, 12); i++) {
+            try {
+                if (await checkboxes.nth(i).isVisible({ timeout: 100 })) visibleCheckboxes++;
+            } catch {
+                // Ignore detached diagnostics candidates.
+            }
+        }
+        if (visibleCheckboxes > 0) {
+            console.log(`      visible checkboxes: ${visibleCheckboxes}`);
+        }
+
+        const controls = frame.locator(controlSelector);
+        const controlCount = await controls.count().catch(() => 0);
+        for (let i = 0; i < Math.min(controlCount, 30); i++) {
+            const control = controls.nth(i);
+            try {
+                if (!(await control.isVisible({ timeout: 100 }))) continue;
+                const text = await control.textContent({ timeout: 300 }).catch(() => "");
+                const ariaLabel = await control.getAttribute("aria-label").catch(() => "");
+                const value = await control.getAttribute("value").catch(() => "");
+                const label = truncateDiagnosticText(text || ariaLabel || value || "<empty>", 180);
+                console.log(`      control[${i}]: ${label}`);
+            } catch {
+                // Ignore detached diagnostics candidates.
+            }
+        }
+    }
+};
+
+const fillTotpInputs = async (page, code) => {
+    const candidates = page.locator(
+        [
+            'input[autocomplete="one-time-code"]',
+            'input[type="tel"]',
+            'input[inputmode="numeric"]',
+            'input[aria-label*="code" i]',
+            'input[aria-label*="verification" i]',
+            'input[aria-label*="验证码"]',
+            'input[placeholder*="code" i]',
+            'input[placeholder*="验证码"]',
+        ].join(", ")
+    );
+
+    const visibleInputs = [];
+    const count = await candidates.count();
+    for (let i = 0; i < Math.min(count, 8); i++) {
+        const input = candidates.nth(i);
+        try {
+            if ((await input.isVisible({ timeout: 250 })) && (await input.isEditable())) {
+                visibleInputs.push(input);
+            }
+        } catch {
+            // Ignore non-editable or detached candidates and continue scanning.
+        }
+    }
+
+    if (visibleInputs.length === 0) return false;
+
+    if (visibleInputs.length === 1) {
+        await visibleInputs[0].fill(code);
+        return true;
+    }
+
+    if (visibleInputs.length >= code.length) {
+        for (let i = 0; i < code.length; i++) {
+            await visibleInputs[i].fill(code[i]);
+        }
+        return true;
+    }
+
+    return false;
+};
+
+const autoFillTotpIfRequired = async (page, totpSecret, randomWait) => {
+    if (!totpSecret) return false;
+
+    for (let attempt = 0; attempt < 20; attempt++) {
+        try {
+            const title = await page.title();
+            if (title.includes("AI Studio")) return false;
+        } catch {
+            // Page may still be navigating.
+        }
+
+        await waitForFreshTotpWindow();
+        const code = generateTotpCode(totpSecret);
+        const filled = await fillTotpInputs(page, code);
+
+        if (filled) {
+            console.log(
+                getText(
+                    "🕵️ 检测到 2FA 验证码输入框，已自动填入 TOTP 验证码。",
+                    "🕵️ Detected a 2FA input and auto-filled a TOTP code."
+                )
+            );
+            await randomWait();
+            await page.keyboard.press("Enter");
+            await randomWait();
+            await clickGoogleTransitionButtons(page, randomWait);
+            return true;
+        }
+
+        await page.waitForTimeout(1000);
+    }
+
+    return false;
+};
+
 (async () => {
     // Use project root directory instead of scripts directory
     const projectRoot = path.join(__dirname, "..", "..");
@@ -110,6 +743,16 @@ const getNextAuthIndex = () => {
         process.exit(1);
     }
 
+    if (runtimeOptions.nonInteractive && (!runtimeOptions.autoFillEmail || !runtimeOptions.autoFillPwd)) {
+        console.error(
+            getText(
+                "❌ 无交互模式需要同时提供邮箱和密码。请通过命令行参数或环境变量设置。",
+                "❌ Non-interactive mode requires both email and password. Provide them via CLI options or environment variables."
+            )
+        );
+        process.exit(1);
+    }
+
     const proxyConfig = parseProxyFromEnv();
     if (proxyConfig) {
         const bypassText = proxyConfig.bypass ? `, bypass=${proxyConfig.bypass}` : "";
@@ -128,20 +771,41 @@ const getNextAuthIndex = () => {
         );
     }
 
+    console.log(
+        getText(
+            `🪟 浏览器模式: ${runtimeOptions.headless ? "headless" : "headed"}`,
+            `🪟 Browser mode: ${runtimeOptions.headless ? "headless" : "headed"}`
+        )
+    );
+    if (runtimeOptions.nonInteractive) {
+        console.log(
+            getText(
+                `⏱️  无交互模式登录超时: ${runtimeOptions.loginTimeoutMs}ms`,
+                `⏱️  Non-interactive login timeout: ${runtimeOptions.loginTimeoutMs}ms`
+            )
+        );
+    }
+    if (runtimeOptions.debugUi) {
+        console.log(
+            getText(
+                "🔎 UI 调试模式已开启：保存认证文件前会输出页面控件诊断并保存截图。",
+                "🔎 UI debug mode enabled: diagnostics and a screenshot will be saved before auth export."
+            )
+        );
+    }
+
     const browser = await firefox.launch({
         executablePath: browserExecutablePath,
-        headless: false,
+        headless: runtimeOptions.headless,
         ...(proxyConfig ? { proxy: proxyConfig } : {}),
     });
 
     const context = await browser.newContext(proxyConfig ? { proxy: proxyConfig } : {});
     const page = await context.newPage();
 
-    // Auto-fill logic
-    const autoFillEmail = process.env.AUTO_FILL_EMAIL;
-    const autoFillPwd = process.env.AUTO_FILL_PWD;
+    const { autoFillEmail, autoFillPwd } = runtimeOptions;
 
-    if (!autoFillEmail) {
+    if (!autoFillEmail && !runtimeOptions.nonInteractive) {
         console.log("");
         console.log(
             getText(
@@ -169,13 +833,13 @@ const getNextAuthIndex = () => {
         );
     }
 
+    const randomWait = () => new Promise(r => setTimeout(r, 1000 + Math.random() * 4000));
+
     // <<< This is the only modification point: updated to Google AI Studio address >>>
     await page.goto("https://aistudio.google.com/u/0/prompts/new_chat");
 
     if (autoFillEmail) {
         try {
-            const randomWait = () => new Promise(r => setTimeout(r, 1000 + Math.random() * 4000));
-
             console.log(
                 getText(
                     `🕵️ 正在尝试自动填入账号: ${autoFillEmail}`,
@@ -194,49 +858,23 @@ const getNextAuthIndex = () => {
                 await page.fill('input[type="password"]', autoFillPwd);
                 await page.keyboard.press("Enter");
 
-                // Handle post-login / 2FA transition pages (e.g. "You're all set" screen with a Next button)
                 try {
-                    // Look for the specific Google transition button
-                    const nextButton = page.locator(
-                        'button:has(span:text("Next")), button:has(span:text("下一步")), button:has-text("Next"), button:has-text("下一步")'
-                    );
-                    const notNowButton = page.locator(
-                        'button:has(span:text("Not now")), button:has(span:text("暂时不")), button:has-text("Not now"), button:has-text("暂时不")'
-                    );
-
-                    // Polling for the transition button for a short duration
-                    for (let i = 0; i < 10; i++) {
-                        if (await nextButton.isVisible({ timeout: 1000 })) {
-                            console.log(
-                                getText(
-                                    "🕵️ 检测到「下一步」按钮，正在点击以跳过说明页...",
-                                    "🕵️ Detected 'Next' button, clicking to skip info page..."
-                                )
-                            );
-                            await nextButton.click();
-                            await randomWait();
-                        } else if (await notNowButton.isVisible({ timeout: 1000 })) {
-                            console.log(
-                                getText(
-                                    "🕵️ 检测到「暂时不」按钮，正在点击以跳过...",
-                                    "🕵️ Detected 'Not now' button, clicking to skip..."
-                                )
-                            );
-                            await notNowButton.click();
-                            await randomWait();
-                        }
-                        const title = await page.title();
-                        if (title.includes("AI Studio")) break;
-                        await page.waitForTimeout(1000);
-                    }
+                    await acceptAiStudioTermsIfPresent(page, randomWait, { rounds: 4 });
+                    await autoFillTotpIfRequired(page, runtimeOptions.totpSecret, randomWait);
+                    await acceptAiStudioTermsIfPresent(page, randomWait, { rounds: 4 });
+                    await clickGoogleTransitionButtons(page, randomWait);
                 } catch (e) {
                     // Best effort
                 }
             }
             console.log(
                 getText(
-                    "🕵️ 自动填充已完成。如有 2FA 请在浏览器中手动完成。",
-                    "🕵️ Auto-fill complete. Please complete 2FA manually if required."
+                    runtimeOptions.totpSecret
+                        ? "🕵️ 自动填充已完成。如有未识别的 2FA 或额外风控，请在浏览器中手动完成。"
+                        : "🕵️ 自动填充已完成。如有 2FA 请在浏览器中手动完成。",
+                    runtimeOptions.totpSecret
+                        ? "🕵️ Auto-fill complete. If there is an unsupported 2FA step or extra risk challenge, complete it manually in the browser."
+                        : "🕵️ Auto-fill complete. Please complete 2FA manually if required."
                 )
             );
         } catch (e) {
@@ -260,7 +898,7 @@ const getNextAuthIndex = () => {
     // Monitoring loop for AI Studio title
     let loginDetected = false;
     const checkInterval = 1000;
-    const maxWaitTime = 300000; // 5 minutes
+    const maxWaitTime = runtimeOptions.loginTimeoutMs;
     const startTime = Date.now();
 
     while (Date.now() - startTime < maxWaitTime) {
@@ -281,6 +919,16 @@ const getNextAuthIndex = () => {
     }
 
     if (!loginDetected) {
+        if (runtimeOptions.nonInteractive) {
+            console.error(
+                getText(
+                    `❌ 在 ${maxWaitTime}ms 内未检测到 AI Studio 登录成功，已退出无交互模式。`,
+                    `❌ Timed out after ${maxWaitTime}ms without detecting a successful AI Studio login. Exiting non-interactive mode.`
+                )
+            );
+            await closeBrowserSafely(browser);
+            process.exit(1);
+        }
         if (autoFillEmail) {
             console.log(
                 getText(
@@ -296,6 +944,17 @@ const getNextAuthIndex = () => {
             )
         );
         await new Promise(resolve => process.stdin.once("data", resolve));
+    }
+
+    try {
+        const acceptedTerms = await acceptAiStudioTermsIfPresent(page, randomWait, { rounds: 8 });
+        if (acceptedTerms) {
+            await page.waitForTimeout(2000);
+        } else {
+            await logAuthUiDiagnostics(page, "保存认证文件前未命中协议确认控件");
+        }
+    } catch {
+        // Agreement handling is best-effort and should not block auth export.
     }
 
     // ==================== Capture Account Name ====================
@@ -405,16 +1064,20 @@ const getNextAuthIndex = () => {
             )
         );
 
-        await browser.close();
+        await closeBrowserSafely(browser);
         console.log("");
         console.log(getText("浏览器已关闭。", "Browser closed."));
         process.exit(1); // Exit with error code when validation fails
     }
     // ===================================================================
 
-    await browser.close();
+    await closeBrowserSafely(browser);
     console.log("");
     console.log(getText("浏览器已关闭。", "Browser closed."));
 
     process.exit(0);
-})();
+})().catch(async error => {
+    console.error("");
+    console.error(getText("错误:", "ERROR:"), error?.message || error);
+    process.exit(1);
+});

--- a/scripts/auth/setupAuth.js
+++ b/scripts/auth/setupAuth.js
@@ -11,6 +11,8 @@ const https = require("https");
 const os = require("os");
 const path = require("path");
 const readline = require("readline");
+const { HttpsProxyAgent, SocksProxyAgent } = require("playwright-core/lib/utilsBundle");
+const { getProxySummaryFromEnv, parseProxyFromEnv } = require("../../src/utils/ProxyUtils");
 
 const DEFAULT_CAMOUFOX_VERSION = "135.0.1-beta.24";
 const GITHUB_RELEASE_TAG_PREFIX = "v";
@@ -22,6 +24,188 @@ let lang = "zh";
 
 // Bilingual text helper
 const getText = (zh, en) => (lang === "zh" ? zh : en);
+
+const normalizeLanguage = value => {
+    const normalized = String(value || "")
+        .trim()
+        .toLowerCase();
+    if (normalized === "2" || normalized === "en" || normalized === "english") {
+        return "en";
+    }
+    return "zh";
+};
+
+const parseBooleanLike = value => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const normalized = String(value).trim().toLowerCase();
+    if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+    return undefined;
+};
+
+const parsePositiveInteger = (value, optionName) => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const parsed = Number.parseInt(String(value), 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(getText(`${optionName} 必须是正整数。`, `${optionName} must be a positive integer.`));
+    }
+    return parsed;
+};
+
+const readRequiredOptionValue = (args, index, optionName) => {
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("-")) {
+        throw new Error(getText(`缺少 ${optionName} 的值。`, `Missing value for ${optionName}.`));
+    }
+    return value;
+};
+
+const parseCliArgs = args => {
+    const options = {
+        headless: undefined,
+        nonInteractive: false,
+    };
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === "-h" || arg === "--help") {
+            options.help = true;
+            continue;
+        }
+        if (arg === "--non-interactive") {
+            options.nonInteractive = true;
+            continue;
+        }
+        if (arg === "--headless") {
+            options.headless = true;
+            continue;
+        }
+        if (arg === "--headed") {
+            options.headless = false;
+            continue;
+        }
+        if (arg === "--debug-ui") {
+            options.debugUi = true;
+            continue;
+        }
+        if (arg.startsWith("--lang=")) {
+            options.lang = arg.slice("--lang=".length);
+            continue;
+        }
+        if (arg === "--lang") {
+            options.lang = readRequiredOptionValue(args, i, "--lang");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--email=")) {
+            options.email = arg.slice("--email=".length);
+            continue;
+        }
+        if (arg === "--email") {
+            options.email = readRequiredOptionValue(args, i, "--email");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--password=")) {
+            options.password = arg.slice("--password=".length);
+            continue;
+        }
+        if (arg === "--password") {
+            options.password = readRequiredOptionValue(args, i, "--password");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--totp-secret=")) {
+            options.totpSecret = arg.slice("--totp-secret=".length);
+            continue;
+        }
+        if (arg === "--totp-secret") {
+            options.totpSecret = readRequiredOptionValue(args, i, "--totp-secret");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--account=")) {
+            options.account = arg.slice("--account=".length);
+            continue;
+        }
+        if (arg === "--account") {
+            options.account = readRequiredOptionValue(args, i, "--account");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--login-timeout-ms=")) {
+            options.loginTimeoutMs = arg.slice("--login-timeout-ms=".length);
+            continue;
+        }
+        if (arg === "--login-timeout-ms") {
+            options.loginTimeoutMs = readRequiredOptionValue(args, i, "--login-timeout-ms");
+            i++;
+            continue;
+        }
+
+        throw new Error(getText(`未知参数: ${arg}`, `Unknown argument: ${arg}`));
+    }
+
+    return options;
+};
+
+const printHelp = () => {
+    console.log("Usage: npm run setup-auth -- [options]");
+    console.log("");
+    console.log("Options:");
+    console.log("  -h, --help                 Show this help message");
+    console.log("  --non-interactive          Run without prompts and exit on timeout/failure");
+    console.log("  --lang <zh|en>             Skip language prompt");
+    console.log("  --email <email>            Auto-fill the Google account email");
+    console.log("  --password <password>      Auto-fill the Google account password");
+    console.log("  --totp-secret <secret>     Auto-fill Google TOTP 2FA code using a Base32 secret");
+    console.log("  --account <index|email>    Select an account from users.csv without prompting");
+    console.log("  --headless                 Launch Camoufox in headless mode");
+    console.log("  --headed                   Force headed mode");
+    console.log("  --login-timeout-ms <ms>    Override login detection timeout");
+    console.log("  --debug-ui                 Dump UI diagnostics before auth export");
+    console.log("");
+    console.log("Environment variables:");
+    console.log("  CAMOUFOX_VERSION=135.0.1-beta.24");
+    console.log("  CAMOUFOX_URL=<direct zip url>");
+    console.log("  CAMOUFOX_EXECUTABLE_PATH=<path to camoufox executable>");
+    console.log("  SETUP_AUTH_NON_INTERACTIVE=true");
+    console.log("  SETUP_AUTH_LANG=zh|en");
+    console.log("  SETUP_AUTH_EMAIL=<email>");
+    console.log("  SETUP_AUTH_PASSWORD=<password>");
+    console.log("  SETUP_AUTH_TOTP_SECRET=<base32 secret>");
+    console.log("  SETUP_AUTH_ACCOUNT=<index or email>");
+    console.log("  SETUP_AUTH_HEADLESS=true");
+    console.log("  SETUP_AUTH_LOGIN_TIMEOUT_MS=300000");
+    console.log("  SETUP_AUTH_DEBUG_UI=true");
+    console.log("");
+    console.log("Examples:");
+    console.log("  npm run setup-auth -- --non-interactive --email your@gmail.com --password your-password --headless");
+    console.log("  npm run setup-auth -- --non-interactive --account 1");
+};
+
+const buildRuntimeOptions = cliOptions => {
+    const langValue = cliOptions.lang ?? process.env.SETUP_AUTH_LANG;
+    const nonInteractive =
+        cliOptions.nonInteractive || parseBooleanLike(process.env.SETUP_AUTH_NON_INTERACTIVE) === true;
+    const headless = cliOptions.headless ?? parseBooleanLike(process.env.SETUP_AUTH_HEADLESS) ?? false;
+
+    return {
+        account: cliOptions.account ?? process.env.SETUP_AUTH_ACCOUNT,
+        debugUi: cliOptions.debugUi ?? parseBooleanLike(process.env.SETUP_AUTH_DEBUG_UI) ?? false,
+        email: cliOptions.email ?? process.env.SETUP_AUTH_EMAIL ?? process.env.AUTO_FILL_EMAIL,
+        hasExplicitLang: langValue !== undefined,
+        headless,
+        lang: normalizeLanguage(langValue),
+        loginTimeoutMs: parsePositiveInteger(
+            cliOptions.loginTimeoutMs ?? process.env.SETUP_AUTH_LOGIN_TIMEOUT_MS,
+            "login-timeout-ms"
+        ),
+        nonInteractive,
+        password: cliOptions.password ?? process.env.SETUP_AUTH_PASSWORD ?? process.env.AUTO_FILL_PWD,
+        totpSecret: cliOptions.totpSecret ?? process.env.SETUP_AUTH_TOTP_SECRET,
+    };
+};
 
 // Prompt user to select language
 const selectLanguage = () =>
@@ -40,67 +224,83 @@ const selectLanguage = () =>
 
         rl.question("> ", answer => {
             rl.close();
-            const trimmed = answer.trim();
-            if (trimmed === "2" || trimmed.toLowerCase() === "en" || trimmed.toLowerCase() === "english") {
-                lang = "en";
-            } else {
-                lang = "zh";
-            }
+            lang = normalizeLanguage(answer);
             resolve(lang);
         });
     });
 
-// Select account from users.csv
-const selectAccountFromCSV = () =>
-    new Promise(resolve => {
-        const csvPath = path.join(PROJECT_ROOT, "users.csv");
-        if (!fs.existsSync(csvPath)) {
-            resolve(null);
-            return;
-        }
-
-        const content = fs.readFileSync(csvPath, "utf-8");
-        const lines = content.split(/\r?\n/).filter(line => line.trim() !== "");
-
-        // CSV parser that handles double quotes
-        const parseCSVLine = line => {
-            const parts = [];
-            let current = "";
-            let inQuotes = false;
-            for (let i = 0; i < line.length; i++) {
-                const char = line[i];
-                if (char === '"') {
-                    if (inQuotes && line[i + 1] === '"') {
-                        current += '"';
-                        i++;
-                    } else {
-                        inQuotes = !inQuotes;
-                    }
-                } else if (char === "," && !inQuotes) {
-                    parts.push(current.trim());
-                    current = "";
-                } else {
-                    current += char;
-                }
+const parseCSVLine = line => {
+    const parts = [];
+    let current = "";
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        if (char === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+                current += '"';
+                i++;
+            } else {
+                inQuotes = !inQuotes;
             }
+        } else if (char === "," && !inQuotes) {
             parts.push(current.trim());
-            return parts;
-        };
+            current = "";
+        } else {
+            current += char;
+        }
+    }
+    parts.push(current.trim());
+    return parts;
+};
 
-        // Filter out headers (lines without @)
-        const accounts = lines
-            .map(line => parseCSVLine(line))
-            .filter(parts => parts.some(p => p.includes("@")))
-            .map(parts => {
-                // Find the first part that looks like an email
-                const emailIdx = parts.findIndex(p => p.includes("@"));
-                const email = parts[emailIdx];
-                // The password is most likely the next column, or the first other non-empty column
-                const password = parts[emailIdx + 1] || parts.find((p, idx) => idx !== emailIdx && p.length > 0);
-                return { email, password };
-            })
-            .filter(acc => acc.email);
+const getAccountsFromCSV = () => {
+    const csvPath = path.join(PROJECT_ROOT, "users.csv");
+    if (!fs.existsSync(csvPath)) return [];
 
+    const content = fs.readFileSync(csvPath, "utf-8");
+    const lines = content.split(/\r?\n/).filter(line => line.trim() !== "");
+
+    return lines
+        .map(line => parseCSVLine(line))
+        .filter(parts => parts.some(p => p.includes("@")))
+        .map((parts, index) => {
+            const emailIdx = parts.findIndex(p => p.includes("@"));
+            const email = parts[emailIdx];
+            const password = parts[emailIdx + 1] || parts.find((p, idx) => idx !== emailIdx && p.length > 0) || "";
+            return { email, index: index + 1, password };
+        })
+        .filter(acc => acc.email);
+};
+
+const findAccountFromCSV = selector => {
+    const accounts = getAccountsFromCSV();
+    if (accounts.length === 0) {
+        throw new Error(getText("未找到可用的 users.csv 账号。", "No accounts found in users.csv."));
+    }
+
+    const trimmedSelector = String(selector || "").trim();
+    if (/^\d+$/.test(trimmedSelector)) {
+        const index = Number.parseInt(trimmedSelector, 10);
+        const account = accounts.find(item => item.index === index);
+        if (!account) {
+            throw new Error(
+                getText(`users.csv 中不存在序号为 ${index} 的账号。`, `No users.csv account found at index ${index}.`)
+            );
+        }
+        return account;
+    }
+
+    const account = accounts.find(item => item.email.toLowerCase() === trimmedSelector.toLowerCase());
+    if (!account) {
+        throw new Error(
+            getText(`users.csv 中不存在账号 ${trimmedSelector}。`, `No users.csv account found for ${trimmedSelector}.`)
+        );
+    }
+    return account;
+};
+
+const selectAccountFromCSV = accounts =>
+    new Promise(resolve => {
         if (accounts.length === 0) {
             resolve(null);
             return;
@@ -117,21 +317,50 @@ const selectAccountFromCSV = () =>
             getText("检测到 users.csv，请选择要预填的账号:", "Detected users.csv, select account to auto-fill:")
         );
         console.log(getText("  0. 不预填 (手动输入)", "  0. Do not auto-fill (manual)"));
-        accounts.forEach((acc, i) => {
-            console.log(`  ${i + 1}. ${acc.email}`);
+        accounts.forEach(acc => {
+            console.log(`  ${acc.index}. ${acc.email}`);
         });
         console.log("==========================================");
 
         rl.question("> ", answer => {
             rl.close();
-            const idx = parseInt(answer.trim());
-            if (!isNaN(idx) && idx > 0 && idx <= accounts.length) {
-                resolve({ ...accounts[idx - 1], index: idx });
+            const idx = parseInt(answer.trim(), 10);
+            if (!Number.isNaN(idx) && idx > 0 && idx <= accounts.length) {
+                resolve(accounts[idx - 1]);
             } else {
                 resolve(null);
             }
         });
     });
+
+const resolveSelectedAccount = async options => {
+    if (options.email) {
+        return {
+            email: options.email,
+            password: options.password || "",
+        };
+    }
+
+    if (options.account) {
+        return findAccountFromCSV(options.account);
+    }
+
+    const accounts = getAccountsFromCSV();
+    if (options.nonInteractive) {
+        if (accounts.length === 1) return accounts[0];
+        if (accounts.length > 1) {
+            throw new Error(
+                getText(
+                    "无交互模式下，当 users.csv 包含多个账号时必须显式指定 --account。",
+                    "In non-interactive mode, --account is required when users.csv contains multiple accounts."
+                )
+            );
+        }
+        return null;
+    }
+
+    return selectAccountFromCSV(accounts);
+};
 
 const execOrThrow = (command, args, options) => {
     const result = spawnSync(command, args, {
@@ -201,12 +430,64 @@ const getCamoufoxInstallConfig = () => {
 
 const downloadFile = async (url, outFilePath) => {
     const maxRedirects = 10;
+    const normalizeProxyURL = proxy => {
+        let normalized = String(proxy || "").trim();
+        if (!/^\w+:\/\//.test(normalized)) {
+            normalized = `http://${normalized}`;
+        }
+        return new URL(normalized);
+    };
+    const shouldBypassProxy = (targetUrl, bypass) => {
+        if (!bypass) return false;
+        const domains = bypass.split(",").map(domain => {
+            let normalized = domain.trim();
+            if (!normalized.startsWith(".")) normalized = `.${normalized}`;
+            return normalized;
+        });
+        const targetDomain = `.${targetUrl.hostname}`;
+        return domains.some(domain => targetDomain.endsWith(domain));
+    };
+    const createProxyAgent = (proxy, targetUrl) => {
+        if (!proxy) return undefined;
+        if (targetUrl && proxy.bypass && shouldBypassProxy(targetUrl, proxy.bypass)) return undefined;
+
+        const proxyUrl = normalizeProxyURL(proxy.server);
+        if (proxyUrl.protocol.startsWith("socks")) {
+            if (proxyUrl.protocol === "socks5:") proxyUrl.protocol = "socks5h:";
+            else if (proxyUrl.protocol === "socks4:") proxyUrl.protocol = "socks4a:";
+            return new SocksProxyAgent(proxyUrl);
+        }
+
+        if (proxy.username) {
+            proxyUrl.username = proxy.username;
+            proxyUrl.password = proxy.password || "";
+        }
+
+        return new HttpsProxyAgent(proxyUrl);
+    };
+    const formatBytes = bytes => {
+        if (!Number.isFinite(bytes) || bytes < 0) return "0 B";
+        if (bytes < 1024) return `${bytes} B`;
+
+        const units = ["KB", "MB", "GB", "TB"];
+        let value = bytes / 1024;
+        let unitIndex = 0;
+        while (value >= 1024 && unitIndex < units.length - 1) {
+            value /= 1024;
+            unitIndex++;
+        }
+        return `${value.toFixed(value >= 100 ? 0 : value >= 10 ? 1 : 2)} ${units[unitIndex]}`;
+    };
 
     const fetchOnce = (currentUrl, redirectsLeft) =>
         new Promise((resolve, reject) => {
+            const targetUrl = new URL(currentUrl);
+            const proxyConfig = parseProxyFromEnv();
+            const agent = createProxyAgent(proxyConfig, targetUrl);
             const request = https.get(
-                currentUrl,
+                targetUrl,
                 {
+                    agent,
                     headers: {
                         Accept: "*/*",
                         "User-Agent": "aistudio-to-api setup-auth",
@@ -247,10 +528,59 @@ const downloadFile = async (url, outFilePath) => {
                         return;
                     }
 
+                    const totalBytes = Number.parseInt(String(res.headers["content-length"] || "0"), 10) || 0;
+                    const downloadStartTime = Date.now();
+                    let downloadedBytes = 0;
+                    let lastLineLength = 0;
+                    let lastRenderAt = 0;
+                    let progressVisible = false;
+
+                    const renderProgress = force => {
+                        if (!process.stdout.isTTY) return;
+
+                        const now = Date.now();
+                        if (!force && now - lastRenderAt < 120) return;
+
+                        const elapsedSeconds = Math.max((now - downloadStartTime) / 1000, 0.001);
+                        const speedBytesPerSecond = downloadedBytes / elapsedSeconds;
+                        const progressText =
+                            totalBytes > 0
+                                ? getText(
+                                      `下载进度: ${((downloadedBytes / totalBytes) * 100).toFixed(1)}% (${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)}) ${formatBytes(speedBytesPerSecond)}/s`,
+                                      `Download progress: ${((downloadedBytes / totalBytes) * 100).toFixed(1)}% (${formatBytes(downloadedBytes)} / ${formatBytes(totalBytes)}) ${formatBytes(speedBytesPerSecond)}/s`
+                                  )
+                                : getText(
+                                      `下载中: ${formatBytes(downloadedBytes)} ${formatBytes(speedBytesPerSecond)}/s`,
+                                      `Downloading: ${formatBytes(downloadedBytes)} ${formatBytes(speedBytesPerSecond)}/s`
+                                  );
+
+                        const paddedText =
+                            progressText.length < lastLineLength
+                                ? progressText + " ".repeat(lastLineLength - progressText.length)
+                                : progressText;
+                        process.stdout.write(`\r${paddedText}`);
+                        lastLineLength = paddedText.length;
+                        lastRenderAt = now;
+                        progressVisible = true;
+                    };
+
                     const fileStream = fs.createWriteStream(outFilePath);
+                    res.on("data", chunk => {
+                        downloadedBytes += chunk.length;
+                        renderProgress(false);
+                    });
                     res.pipe(fileStream);
-                    fileStream.on("finish", () => fileStream.close(() => resolve()));
+                    fileStream.on("finish", () => {
+                        renderProgress(true);
+                        if (progressVisible) {
+                            process.stdout.write("\n");
+                        }
+                        fileStream.close(() => resolve());
+                    });
                     fileStream.on("error", err => {
+                        if (progressVisible) {
+                            process.stdout.write("\n");
+                        }
                         try {
                             fs.unlinkSync(outFilePath);
                         } catch {
@@ -443,10 +773,26 @@ const ensureCamoufoxExecutable = async () => {
     ensureDir(installDir);
 
     const zipFilePath = path.join(PROJECT_ROOT, "camoufox.zip");
+    const proxySummary = getProxySummaryFromEnv();
 
     console.log(getText("[2/4] 检查 Camoufox...", "[2/4] Checking Camoufox..."));
     console.log(getText(`正在下载 Camoufox (${version})...`, `Downloading Camoufox (${version})...`));
     console.log(getText(`下载地址: ${downloadUrl}`, `Download URL: ${downloadUrl}`));
+    if (proxySummary.enabled) {
+        console.log(
+            getText(
+                `下载代理: ${proxySummary.server}${proxySummary.envKey ? ` (${proxySummary.envKey})` : ""}`,
+                `Download proxy: ${proxySummary.server}${proxySummary.envKey ? ` (${proxySummary.envKey})` : ""}`
+            )
+        );
+    } else {
+        console.log(
+            getText(
+                "下载代理: 未检测到代理环境变量，当前为直连下载。",
+                "Download proxy: no proxy environment variable detected, downloading directly."
+            )
+        );
+    }
 
     await downloadFile(downloadUrl, zipFilePath);
     console.log(getText("下载完成。", "Download complete."));
@@ -530,23 +876,34 @@ const loadEnvConfig = () => {
     require("dotenv").config({ path: path.resolve(__dirname, "..", "..", ".env") });
 };
 
-const runSaveAuth = (camoufoxExecutablePath, selectedAccount) => {
+const runSaveAuth = (camoufoxExecutablePath, selectedAccount, options) => {
     console.log(getText("[4/4] 启动认证保存工具...", "[4/4] Starting auth save tool..."));
     console.log("");
     console.log("==========================================");
-    console.log(getText("  请按提示在新打开的 Camoufox 窗口中操作", "  Please follow the prompts to login"));
+    console.log(
+        options.nonInteractive
+            ? getText("  正在以无交互模式运行认证流程", "  Running authentication flow in non-interactive mode")
+            : getText("  请按提示在新打开的 Camoufox 窗口中操作", "  Please follow the prompts to login")
+    );
     console.log("==========================================");
     console.log("");
 
     const env = {
         ...process.env,
         CAMOUFOX_EXECUTABLE_PATH: camoufoxExecutablePath,
+        SETUP_AUTH_DEBUG_UI: String(options.debugUi),
+        SETUP_AUTH_HEADLESS: String(options.headless),
         SETUP_AUTH_LANG: lang, // Pass selected language to saveAuth.js
+        SETUP_AUTH_LOGIN_TIMEOUT_MS: String(options.loginTimeoutMs || 300000),
+        SETUP_AUTH_NON_INTERACTIVE: String(options.nonInteractive),
     };
 
     if (selectedAccount) {
         env.AUTO_FILL_EMAIL = selectedAccount.email;
         env.AUTO_FILL_PWD = selectedAccount.password;
+    }
+    if (options.totpSecret) {
+        env.SETUP_AUTH_TOTP_SECRET = options.totpSecret;
     }
 
     const result = spawnSync(process.execPath, [path.join("scripts", "auth", "saveAuth.js")], {
@@ -564,22 +921,25 @@ const runSaveAuth = (camoufoxExecutablePath, selectedAccount) => {
 };
 
 const main = async () => {
-    const args = process.argv.slice(2);
-    if (args.includes("-h") || args.includes("--help")) {
-        console.log("Usage: npm run setup-auth");
-        console.log("");
-        console.log("Optional env vars:");
-        console.log("  CAMOUFOX_VERSION=135.0.1-beta.24");
-        console.log("  CAMOUFOX_URL=<direct zip url>");
-        console.log("  CAMOUFOX_EXECUTABLE_PATH=<path to camoufox executable>");
+    const cliOptions = parseCliArgs(process.argv.slice(2));
+    if (cliOptions.help) {
+        printHelp();
         process.exit(0);
     }
 
-    // Ask user to select language first
-    await selectLanguage();
+    if (cliOptions.lang !== undefined) {
+        lang = normalizeLanguage(cliOptions.lang);
+    }
 
-    // Check for users.csv and ask for account selection
-    const selectedAccount = await selectAccountFromCSV();
+    ensureNodeModules();
+    loadEnvConfig();
+
+    const options = buildRuntimeOptions(cliOptions);
+    if (options.hasExplicitLang || options.nonInteractive) {
+        lang = options.lang;
+    } else {
+        await selectLanguage();
+    }
 
     console.log("");
     console.log("==========================================");
@@ -588,8 +948,25 @@ const main = async () => {
     console.log(getText(`操作系统: ${os.platform()}  架构: ${os.arch()}`, `OS: ${os.platform()}  Arch: ${os.arch()}`));
     console.log("");
 
-    ensureNodeModules();
-    loadEnvConfig();
+    const selectedAccount = await resolveSelectedAccount(options);
+    if (options.nonInteractive) {
+        if (!selectedAccount?.email) {
+            throw new Error(
+                getText(
+                    "无交互模式需要可用的账号凭据。请使用 --email/--password，或通过 --account 从 users.csv 选择账号。",
+                    "Non-interactive mode requires account credentials. Use --email/--password or select one from users.csv via --account."
+                )
+            );
+        }
+        if (!selectedAccount.password) {
+            throw new Error(
+                getText(
+                    "无交互模式需要账号密码。请补充 --password，或确保 users.csv 中包含该账号的密码。",
+                    "Non-interactive mode requires a password. Provide --password or ensure the selected users.csv entry includes one."
+                )
+            );
+        }
+    }
 
     let camoufoxExecutablePath = process.env.CAMOUFOX_EXECUTABLE_PATH;
     if (!camoufoxExecutablePath) {
@@ -610,7 +987,7 @@ const main = async () => {
         );
     }
 
-    runSaveAuth(camoufoxExecutablePath, selectedAccount);
+    runSaveAuth(camoufoxExecutablePath, selectedAccount, options);
 
     console.log("");
     console.log("==========================================");

--- a/scripts/auth/setupAuth.js
+++ b/scripts/auth/setupAuth.js
@@ -253,23 +253,51 @@ const parseCSVLine = line => {
     return parts;
 };
 
+const getHeaderIndex = (header, patterns) =>
+    header.findIndex(column => patterns.some(pattern => pattern.test(String(column || "").trim())));
+
 const getAccountsFromCSV = () => {
     const csvPath = path.join(PROJECT_ROOT, "users.csv");
     if (!fs.existsSync(csvPath)) return [];
 
     const content = fs.readFileSync(csvPath, "utf-8");
-    const lines = content.split(/\r?\n/).filter(line => line.trim() !== "");
+    const rows = content
+        .split(/\r?\n/)
+        .filter(line => line.trim() !== "")
+        .map(line => parseCSVLine(line));
 
-    return lines
-        .map(line => parseCSVLine(line))
-        .filter(parts => parts.some(p => p.includes("@")))
+    if (rows.length === 0) return [];
+
+    const firstRow = rows[0].map(part => part.trim());
+    const hasHeader =
+        !firstRow.some(part => part.includes("@")) &&
+        getHeaderIndex(firstRow, [/^email$/i, /^account$/i, /^账号$/, /^邮箱$/]) !== -1;
+    const accountRows = hasHeader ? rows.slice(1) : rows;
+    const emailHeaderIndex = hasHeader ? getHeaderIndex(firstRow, [/^email$/i, /^account$/i, /^账号$/, /^邮箱$/]) : -1;
+    const passwordHeaderIndex = hasHeader
+        ? getHeaderIndex(firstRow, [/^password$/i, /^pwd$/i, /^pass$/i, /^密码$/])
+        : -1;
+    const totpHeaderIndex = hasHeader ? getHeaderIndex(firstRow, [/^totp/i, /^otp/i, /^2fa/i, /secret/i, /密钥/]) : -1;
+
+    return accountRows
         .map((parts, index) => {
-            const emailIdx = parts.findIndex(p => p.includes("@"));
+            const emailIdx = hasHeader ? emailHeaderIndex : parts.findIndex(p => p.includes("@"));
+            if (emailIdx === -1) return null;
+
             const email = parts[emailIdx];
-            const password = parts[emailIdx + 1] || parts.find((p, idx) => idx !== emailIdx && p.length > 0) || "";
-            return { email, index: index + 1, password };
+            const password = hasHeader
+                ? parts[passwordHeaderIndex] || ""
+                : parts[emailIdx + 1] || parts.find((p, idx) => idx !== emailIdx && p.length > 0) || "";
+            const totpSecret = hasHeader ? parts[totpHeaderIndex] || "" : parts[emailIdx + 2] || "";
+
+            return {
+                email,
+                index: index + 1,
+                password,
+                totpSecret,
+            };
         })
-        .filter(acc => acc.email);
+        .filter(acc => acc?.email);
 };
 
 const findAccountFromCSV = selector => {
@@ -902,8 +930,9 @@ const runSaveAuth = (camoufoxExecutablePath, selectedAccount, options) => {
         env.AUTO_FILL_EMAIL = selectedAccount.email;
         env.AUTO_FILL_PWD = selectedAccount.password;
     }
-    if (options.totpSecret) {
-        env.SETUP_AUTH_TOTP_SECRET = options.totpSecret;
+    const totpSecret = options.totpSecret || selectedAccount?.totpSecret;
+    if (totpSecret) {
+        env.SETUP_AUTH_TOTP_SECRET = totpSecret;
     }
 
     const result = spawnSync(process.execPath, [path.join("scripts", "auth", "saveAuth.js")], {

--- a/scripts/auth/setupAuth.js
+++ b/scripts/auth/setupAuth.js
@@ -115,6 +115,15 @@ const parseCliArgs = args => {
             i++;
             continue;
         }
+        if (arg.startsWith("--recovery-email=")) {
+            options.recoveryEmail = arg.slice("--recovery-email=".length);
+            continue;
+        }
+        if (arg === "--recovery-email") {
+            options.recoveryEmail = readRequiredOptionValue(args, i, "--recovery-email");
+            i++;
+            continue;
+        }
         if (arg.startsWith("--totp-secret=")) {
             options.totpSecret = arg.slice("--totp-secret=".length);
             continue;
@@ -158,6 +167,7 @@ const printHelp = () => {
     console.log("  --lang <zh|en>             Skip language prompt");
     console.log("  --email <email>            Auto-fill the Google account email");
     console.log("  --password <password>      Auto-fill the Google account password");
+    console.log("  --recovery-email <email>   Auto-fill Google recovery email challenge");
     console.log("  --totp-secret <secret>     Auto-fill Google TOTP 2FA code using a Base32 secret");
     console.log("  --account <index|email>    Select an account from users.csv without prompting");
     console.log("  --headless                 Launch Camoufox in headless mode");
@@ -173,6 +183,7 @@ const printHelp = () => {
     console.log("  SETUP_AUTH_LANG=zh|en");
     console.log("  SETUP_AUTH_EMAIL=<email>");
     console.log("  SETUP_AUTH_PASSWORD=<password>");
+    console.log("  SETUP_AUTH_RECOVERY_EMAIL=<recovery email>");
     console.log("  SETUP_AUTH_TOTP_SECRET=<base32 secret>");
     console.log("  SETUP_AUTH_ACCOUNT=<index or email>");
     console.log("  SETUP_AUTH_HEADLESS=true");
@@ -203,6 +214,7 @@ const buildRuntimeOptions = cliOptions => {
         ),
         nonInteractive,
         password: cliOptions.password ?? process.env.SETUP_AUTH_PASSWORD ?? process.env.AUTO_FILL_PWD,
+        recoveryEmail: cliOptions.recoveryEmail ?? process.env.SETUP_AUTH_RECOVERY_EMAIL,
         totpSecret: cliOptions.totpSecret ?? process.env.SETUP_AUTH_TOTP_SECRET,
     };
 };
@@ -277,6 +289,9 @@ const getAccountsFromCSV = () => {
     const passwordHeaderIndex = hasHeader
         ? getHeaderIndex(firstRow, [/^password$/i, /^pwd$/i, /^pass$/i, /^密码$/])
         : -1;
+    const recoveryHeaderIndex = hasHeader
+        ? getHeaderIndex(firstRow, [/^recovery/i, /recovery.*email/i, /^辅助邮箱$/, /^恢复邮箱$/, /^备用邮箱$/])
+        : -1;
     const totpHeaderIndex = hasHeader ? getHeaderIndex(firstRow, [/^totp/i, /^otp/i, /^2fa/i, /secret/i, /密钥/]) : -1;
 
     return accountRows
@@ -288,12 +303,21 @@ const getAccountsFromCSV = () => {
             const password = hasHeader
                 ? parts[passwordHeaderIndex] || ""
                 : parts[emailIdx + 1] || parts.find((p, idx) => idx !== emailIdx && p.length > 0) || "";
-            const totpSecret = hasHeader ? parts[totpHeaderIndex] || "" : parts[emailIdx + 2] || "";
+            const thirdValue = parts[emailIdx + 2] || "";
+            const recoveryEmail = hasHeader
+                ? parts[recoveryHeaderIndex] || ""
+                : thirdValue.includes("@")
+                  ? thirdValue
+                  : "";
+            const totpSecret = hasHeader
+                ? parts[totpHeaderIndex] || ""
+                : parts[emailIdx + 3] || (thirdValue && !thirdValue.includes("@") ? thirdValue : "");
 
             return {
                 email,
                 index: index + 1,
                 password,
+                recoveryEmail,
                 totpSecret,
             };
         })
@@ -929,6 +953,10 @@ const runSaveAuth = (camoufoxExecutablePath, selectedAccount, options) => {
     if (selectedAccount) {
         env.AUTO_FILL_EMAIL = selectedAccount.email;
         env.AUTO_FILL_PWD = selectedAccount.password;
+    }
+    const recoveryEmail = options.recoveryEmail || selectedAccount?.recoveryEmail;
+    if (recoveryEmail) {
+        env.SETUP_AUTH_RECOVERY_EMAIL = recoveryEmail;
     }
     const totpSecret = options.totpSecret || selectedAccount?.totpSecret;
     if (totpSecret) {

--- a/scripts/auth/setupAuthBatch.js
+++ b/scripts/auth/setupAuthBatch.js
@@ -1,0 +1,456 @@
+/**
+ * File: scripts/auth/setupAuthBatch.js
+ * Description: Batch wrapper for setup-auth, reading users.csv and generating auth files account by account.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+require("dotenv").config({ path: path.resolve(__dirname, "..", "..", ".env") });
+
+const PROJECT_ROOT = path.join(__dirname, "..", "..");
+
+const normalizeLanguage = value => {
+    const normalized = String(value || "")
+        .trim()
+        .toLowerCase();
+    if (normalized === "2" || normalized === "en" || normalized === "english") {
+        return "en";
+    }
+    return "zh";
+};
+
+let lang = normalizeLanguage(process.env.SETUP_AUTH_BATCH_LANG || process.env.SETUP_AUTH_LANG || "zh");
+const getText = (zh, en) => (lang === "zh" ? zh : en);
+
+const parseBooleanLike = value => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const normalized = String(value).trim().toLowerCase();
+    if (["1", "true", "yes", "y", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "n", "off"].includes(normalized)) return false;
+    return undefined;
+};
+
+const parseNonNegativeInteger = (value, optionName) => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const parsed = Number.parseInt(String(value), 10);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+        throw new Error(getText(`${optionName} 必须是非负整数。`, `${optionName} must be a non-negative integer.`));
+    }
+    return parsed;
+};
+
+const parsePositiveInteger = (value, optionName) => {
+    if (value === undefined || value === null || value === "") return undefined;
+    const parsed = Number.parseInt(String(value), 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(getText(`${optionName} 必须是正整数。`, `${optionName} must be a positive integer.`));
+    }
+    return parsed;
+};
+
+const readRequiredOptionValue = (args, index, optionName) => {
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("-")) {
+        throw new Error(getText(`缺少 ${optionName} 的值。`, `Missing value for ${optionName}.`));
+    }
+    return value;
+};
+
+const parseCliArgs = args => {
+    const options = {
+        continueOnError: undefined,
+        debugUi: undefined,
+        headless: undefined,
+    };
+
+    for (let i = 0; i < args.length; i++) {
+        const arg = args[i];
+        if (arg === "-h" || arg === "--help") {
+            options.help = true;
+            continue;
+        }
+        if (arg === "--continue-on-error") {
+            options.continueOnError = true;
+            continue;
+        }
+        if (arg === "--stop-on-error") {
+            options.continueOnError = false;
+            continue;
+        }
+        if (arg === "--headless") {
+            options.headless = true;
+            continue;
+        }
+        if (arg === "--headed") {
+            options.headless = false;
+            continue;
+        }
+        if (arg === "--debug-ui") {
+            options.debugUi = true;
+            continue;
+        }
+        if (arg.startsWith("--csv=")) {
+            options.csv = arg.slice("--csv=".length);
+            continue;
+        }
+        if (arg === "--csv") {
+            options.csv = readRequiredOptionValue(args, i, "--csv");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--accounts=")) {
+            options.accounts = arg.slice("--accounts=".length);
+            continue;
+        }
+        if (arg === "--accounts") {
+            options.accounts = readRequiredOptionValue(args, i, "--accounts");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--delay-ms=")) {
+            options.delayMs = arg.slice("--delay-ms=".length);
+            continue;
+        }
+        if (arg === "--delay-ms") {
+            options.delayMs = readRequiredOptionValue(args, i, "--delay-ms");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--lang=")) {
+            options.lang = arg.slice("--lang=".length);
+            continue;
+        }
+        if (arg === "--lang") {
+            options.lang = readRequiredOptionValue(args, i, "--lang");
+            i++;
+            continue;
+        }
+        if (arg.startsWith("--login-timeout-ms=")) {
+            options.loginTimeoutMs = arg.slice("--login-timeout-ms=".length);
+            continue;
+        }
+        if (arg === "--login-timeout-ms") {
+            options.loginTimeoutMs = readRequiredOptionValue(args, i, "--login-timeout-ms");
+            i++;
+            continue;
+        }
+
+        throw new Error(getText(`未知参数: ${arg}`, `Unknown argument: ${arg}`));
+    }
+
+    return options;
+};
+
+const printHelp = () => {
+    console.log("Usage: npm run setup-auth-batch -- [options]");
+    console.log("");
+    console.log("Options:");
+    console.log("  -h, --help                 Show this help message");
+    console.log("  --csv <path>               CSV file path, defaults to users.csv");
+    console.log("  --accounts <list>          Account selectors: all, 1, 1,3-5, or email");
+    console.log("  --headless                 Run browser in headless mode (default)");
+    console.log("  --headed                   Force headed mode");
+    console.log("  --debug-ui                 Dump UI diagnostics before auth export");
+    console.log("  --continue-on-error        Continue with remaining accounts if one account fails");
+    console.log("  --stop-on-error            Stop at first failed account (default)");
+    console.log("  --delay-ms <ms>            Delay between accounts, defaults to 1000");
+    console.log("  --lang <zh|en>             Override output language");
+    console.log("  --login-timeout-ms <ms>    Override per-account login detection timeout");
+    console.log("");
+    console.log("CSV columns:");
+    console.log("  email,password,totp_secret");
+    console.log("");
+    console.log("Environment variables:");
+    console.log("  SETUP_AUTH_BATCH_ACCOUNTS=all");
+    console.log("  SETUP_AUTH_BATCH_CONTINUE_ON_ERROR=true");
+    console.log("  SETUP_AUTH_BATCH_CSV=users.csv");
+    console.log("  SETUP_AUTH_BATCH_DELAY_MS=1000");
+    console.log("  SETUP_AUTH_BATCH_LANG=zh|en");
+    console.log("  SETUP_AUTH_HEADLESS=true");
+    console.log("  SETUP_AUTH_LOGIN_TIMEOUT_MS=300000");
+    console.log("  SETUP_AUTH_DEBUG_UI=true");
+};
+
+const buildRuntimeOptions = cliOptions => {
+    const langValue = cliOptions.lang ?? process.env.SETUP_AUTH_BATCH_LANG ?? process.env.SETUP_AUTH_LANG;
+    const csvValue = cliOptions.csv ?? process.env.SETUP_AUTH_BATCH_CSV ?? "users.csv";
+
+    return {
+        accounts: cliOptions.accounts ?? process.env.SETUP_AUTH_BATCH_ACCOUNTS ?? "all",
+        continueOnError:
+            cliOptions.continueOnError ?? parseBooleanLike(process.env.SETUP_AUTH_BATCH_CONTINUE_ON_ERROR) ?? false,
+        csvPath: path.resolve(PROJECT_ROOT, csvValue),
+        debugUi: cliOptions.debugUi ?? parseBooleanLike(process.env.SETUP_AUTH_DEBUG_UI) ?? false,
+        delayMs:
+            parseNonNegativeInteger(cliOptions.delayMs ?? process.env.SETUP_AUTH_BATCH_DELAY_MS, "delay-ms") ?? 1000,
+        headless: cliOptions.headless ?? parseBooleanLike(process.env.SETUP_AUTH_HEADLESS) ?? true,
+        lang: normalizeLanguage(langValue),
+        loginTimeoutMs: parsePositiveInteger(
+            cliOptions.loginTimeoutMs ?? process.env.SETUP_AUTH_LOGIN_TIMEOUT_MS,
+            "login-timeout-ms"
+        ),
+    };
+};
+
+const parseCSVLine = line => {
+    const parts = [];
+    let current = "";
+    let inQuotes = false;
+    for (let i = 0; i < line.length; i++) {
+        const char = line[i];
+        if (char === '"') {
+            if (inQuotes && line[i + 1] === '"') {
+                current += '"';
+                i++;
+            } else {
+                inQuotes = !inQuotes;
+            }
+        } else if (char === "," && !inQuotes) {
+            parts.push(current.trim());
+            current = "";
+        } else {
+            current += char;
+        }
+    }
+    parts.push(current.trim());
+    return parts;
+};
+
+const getHeaderIndex = (header, patterns) =>
+    header.findIndex(column => patterns.some(pattern => pattern.test(String(column || "").trim())));
+
+const parseAccountRowWithHeader = (parts, header, index) => {
+    const emailIndex = getHeaderIndex(header, [/^email$/i, /^account$/i, /^账号$/, /^邮箱$/]);
+    const passwordIndex = getHeaderIndex(header, [/^password$/i, /^pwd$/i, /^pass$/i, /^密码$/]);
+    const totpIndex = getHeaderIndex(header, [/^totp/i, /^otp/i, /^2fa/i, /secret/i, /密钥/]);
+
+    const email = emailIndex >= 0 ? parts[emailIndex] : "";
+    const password = passwordIndex >= 0 ? parts[passwordIndex] || "" : "";
+    const totpSecret = totpIndex >= 0 ? parts[totpIndex] || "" : "";
+
+    return email
+        ? {
+              email,
+              index,
+              password,
+              totpSecret,
+          }
+        : null;
+};
+
+const parseAccountRowWithoutHeader = (parts, index) => {
+    const emailIndex = parts.findIndex(part => part.includes("@"));
+    if (emailIndex === -1) return null;
+
+    return {
+        email: parts[emailIndex],
+        index,
+        password:
+            parts[emailIndex + 1] || parts.find((part, partIndex) => partIndex !== emailIndex && part.length > 0) || "",
+        totpSecret: parts[emailIndex + 2] || "",
+    };
+};
+
+const getAccountsFromCSV = csvPath => {
+    if (!fs.existsSync(csvPath)) {
+        throw new Error(getText(`未找到 CSV 文件: ${csvPath}`, `CSV file not found: ${csvPath}`));
+    }
+
+    const content = fs.readFileSync(csvPath, "utf-8");
+    const rows = content
+        .split(/\r?\n/)
+        .filter(line => line.trim() !== "")
+        .map(line => parseCSVLine(line));
+
+    if (rows.length === 0) {
+        throw new Error(getText(`CSV 文件为空: ${csvPath}`, `CSV file is empty: ${csvPath}`));
+    }
+
+    const firstRow = rows[0].map(part => part.trim());
+    const hasHeader =
+        !firstRow.some(part => part.includes("@")) && getHeaderIndex(firstRow, [/^email$/i, /^账号$/, /^邮箱$/]) !== -1;
+    const accountRows = hasHeader ? rows.slice(1) : rows;
+    const header = hasHeader ? firstRow : [];
+
+    return accountRows
+        .map((parts, offset) =>
+            hasHeader
+                ? parseAccountRowWithHeader(parts, header, offset + 1)
+                : parseAccountRowWithoutHeader(parts, offset + 1)
+        )
+        .filter(Boolean);
+};
+
+const addAccountByIndex = (accounts, selected, seen, index) => {
+    const account = accounts.find(item => item.index === index);
+    if (!account) {
+        throw new Error(
+            getText(`users.csv 中不存在序号为 ${index} 的账号。`, `No users.csv account found at index ${index}.`)
+        );
+    }
+    if (!seen.has(account.email)) {
+        selected.push(account);
+        seen.add(account.email);
+    }
+};
+
+const selectAccounts = (accounts, selectorValue) => {
+    const selector = String(selectorValue || "all").trim();
+    if (!selector || selector.toLowerCase() === "all") return accounts;
+
+    const selected = [];
+    const seen = new Set();
+    for (const token of selector
+        .split(",")
+        .map(part => part.trim())
+        .filter(Boolean)) {
+        const rangeMatch = token.match(/^(\d+)-(\d+)$/);
+        if (rangeMatch) {
+            const start = Number.parseInt(rangeMatch[1], 10);
+            const end = Number.parseInt(rangeMatch[2], 10);
+            if (start > end) {
+                throw new Error(getText(`账号范围无效: ${token}`, `Invalid account range: ${token}`));
+            }
+            for (let index = start; index <= end; index++) {
+                addAccountByIndex(accounts, selected, seen, index);
+            }
+            continue;
+        }
+
+        if (/^\d+$/.test(token)) {
+            addAccountByIndex(accounts, selected, seen, Number.parseInt(token, 10));
+            continue;
+        }
+
+        const account = accounts.find(item => item.email.toLowerCase() === token.toLowerCase());
+        if (!account) {
+            throw new Error(getText(`users.csv 中不存在账号 ${token}。`, `No users.csv account found for ${token}.`));
+        }
+        if (!seen.has(account.email)) {
+            selected.push(account);
+            seen.add(account.email);
+        }
+    }
+
+    return selected;
+};
+
+const maskEmail = email => email.replace(/^(.{2}).*(@.*)$/, "$1***$2");
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const runSetupAuthForAccount = (account, options) => {
+    const args = [
+        path.join("scripts", "auth", "setupAuth.js"),
+        "--non-interactive",
+        "--email",
+        account.email,
+        "--password",
+        account.password,
+        "--lang",
+        options.lang,
+    ];
+
+    args.push(options.headless ? "--headless" : "--headed");
+    if (options.debugUi) args.push("--debug-ui");
+    if (options.loginTimeoutMs) args.push("--login-timeout-ms", String(options.loginTimeoutMs));
+    if (account.totpSecret) args.push("--totp-secret", account.totpSecret);
+
+    return spawnSync(process.execPath, args, {
+        cwd: PROJECT_ROOT,
+        env: {
+            ...process.env,
+            SETUP_AUTH_BATCH_RUNNING: "true",
+        },
+        stdio: "inherit",
+    });
+};
+
+const main = async () => {
+    const cliOptions = parseCliArgs(process.argv.slice(2));
+    if (cliOptions.help) {
+        printHelp();
+        process.exit(0);
+    }
+
+    const options = buildRuntimeOptions(cliOptions);
+    lang = options.lang;
+
+    const accounts = getAccountsFromCSV(options.csvPath);
+    const selectedAccounts = selectAccounts(accounts, options.accounts);
+    if (selectedAccounts.length === 0) {
+        throw new Error(getText("没有可处理的账号。", "No accounts selected."));
+    }
+
+    const missingPassword = selectedAccounts.find(account => !account.password);
+    if (missingPassword) {
+        throw new Error(
+            getText(
+                `账号 ${missingPassword.email} 缺少密码，无法无交互批量添加。`,
+                `Account ${missingPassword.email} is missing a password and cannot be added non-interactively.`
+            )
+        );
+    }
+
+    console.log("");
+    console.log("==========================================");
+    console.log(getText("  AI Studio To API - 批量认证设置", "  AI Studio To API - Batch Auth Setup"));
+    console.log("==========================================");
+    console.log(getText(`CSV 文件: ${options.csvPath}`, `CSV file: ${options.csvPath}`));
+    console.log(getText(`待处理账号数: ${selectedAccounts.length}`, `Accounts to process: ${selectedAccounts.length}`));
+    console.log("");
+
+    const failures = [];
+    for (let i = 0; i < selectedAccounts.length; i++) {
+        const account = selectedAccounts[i];
+        console.log("");
+        console.log("==========================================");
+        console.log(
+            getText(
+                `  [${i + 1}/${selectedAccounts.length}] 正在添加账号: ${maskEmail(account.email)}`,
+                `  [${i + 1}/${selectedAccounts.length}] Adding account: ${maskEmail(account.email)}`
+            )
+        );
+        console.log("==========================================");
+
+        const result = runSetupAuthForAccount(account, options);
+        const failed = result.error || (typeof result.status === "number" && result.status !== 0);
+        if (failed) {
+            const message = result.error?.message || `exit code ${result.status}`;
+            failures.push({ email: account.email, message });
+            console.error(
+                getText(`账号 ${account.email} 添加失败: ${message}`, `Failed to add ${account.email}: ${message}`)
+            );
+            if (!options.continueOnError) break;
+        }
+
+        if (i < selectedAccounts.length - 1 && options.delayMs > 0) {
+            await sleep(options.delayMs);
+        }
+    }
+
+    console.log("");
+    console.log("==========================================");
+    console.log(getText("  批量认证设置完成", "  Batch auth setup complete"));
+    console.log("==========================================");
+    console.log(
+        getText(
+            `成功: ${selectedAccounts.length - failures.length}`,
+            `Succeeded: ${selectedAccounts.length - failures.length}`
+        )
+    );
+    console.log(getText(`失败: ${failures.length}`, `Failed: ${failures.length}`));
+    for (const failure of failures) {
+        console.log(`  - ${failure.email}: ${failure.message}`);
+    }
+
+    if (failures.length > 0) process.exit(1);
+};
+
+main().catch(error => {
+    console.error("");
+    console.error(getText("错误:", "ERROR:"), error?.message || error);
+    process.exit(1);
+});

--- a/scripts/auth/setupAuthBatch.js
+++ b/scripts/auth/setupAuthBatch.js
@@ -160,7 +160,7 @@ const printHelp = () => {
     console.log("  --login-timeout-ms <ms>    Override per-account login detection timeout");
     console.log("");
     console.log("CSV columns:");
-    console.log("  email,password,totp_secret");
+    console.log("  email,password,recovery_email,totp_secret");
     console.log("");
     console.log("Environment variables:");
     console.log("  SETUP_AUTH_BATCH_ACCOUNTS=all");
@@ -224,10 +224,18 @@ const getHeaderIndex = (header, patterns) =>
 const parseAccountRowWithHeader = (parts, header, index) => {
     const emailIndex = getHeaderIndex(header, [/^email$/i, /^account$/i, /^账号$/, /^邮箱$/]);
     const passwordIndex = getHeaderIndex(header, [/^password$/i, /^pwd$/i, /^pass$/i, /^密码$/]);
+    const recoveryIndex = getHeaderIndex(header, [
+        /^recovery/i,
+        /recovery.*email/i,
+        /^辅助邮箱$/,
+        /^恢复邮箱$/,
+        /^备用邮箱$/,
+    ]);
     const totpIndex = getHeaderIndex(header, [/^totp/i, /^otp/i, /^2fa/i, /secret/i, /密钥/]);
 
     const email = emailIndex >= 0 ? parts[emailIndex] : "";
     const password = passwordIndex >= 0 ? parts[passwordIndex] || "" : "";
+    const recoveryEmail = recoveryIndex >= 0 ? parts[recoveryIndex] || "" : "";
     const totpSecret = totpIndex >= 0 ? parts[totpIndex] || "" : "";
 
     return email
@@ -235,6 +243,7 @@ const parseAccountRowWithHeader = (parts, header, index) => {
               email,
               index,
               password,
+              recoveryEmail,
               totpSecret,
           }
         : null;
@@ -244,12 +253,15 @@ const parseAccountRowWithoutHeader = (parts, index) => {
     const emailIndex = parts.findIndex(part => part.includes("@"));
     if (emailIndex === -1) return null;
 
+    const thirdValue = parts[emailIndex + 2] || "";
+
     return {
         email: parts[emailIndex],
         index,
         password:
             parts[emailIndex + 1] || parts.find((part, partIndex) => partIndex !== emailIndex && part.length > 0) || "",
-        totpSecret: parts[emailIndex + 2] || "",
+        recoveryEmail: thirdValue.includes("@") ? thirdValue : "",
+        totpSecret: parts[emailIndex + 3] || (thirdValue && !thirdValue.includes("@") ? thirdValue : ""),
     };
 };
 
@@ -270,7 +282,8 @@ const getAccountsFromCSV = csvPath => {
 
     const firstRow = rows[0].map(part => part.trim());
     const hasHeader =
-        !firstRow.some(part => part.includes("@")) && getHeaderIndex(firstRow, [/^email$/i, /^账号$/, /^邮箱$/]) !== -1;
+        !firstRow.some(part => part.includes("@")) &&
+        getHeaderIndex(firstRow, [/^email$/i, /^account$/i, /^账号$/, /^邮箱$/]) !== -1;
     const accountRows = hasHeader ? rows.slice(1) : rows;
     const header = hasHeader ? firstRow : [];
 
@@ -356,6 +369,7 @@ const runSetupAuthForAccount = (account, options) => {
     args.push(options.headless ? "--headless" : "--headed");
     if (options.debugUi) args.push("--debug-ui");
     if (options.loginTimeoutMs) args.push("--login-timeout-ms", String(options.loginTimeoutMs));
+    if (account.recoveryEmail) args.push("--recovery-email", account.recoveryEmail);
     if (account.totpSecret) args.push("--totp-secret", account.totpSecret);
 
     return spawnSync(process.execPath, args, {


### PR DESCRIPTION
  ## Summary
  - Add non-interactive auth setup for generating AI Studio auth files
  - Add email/password auto-fill, TOTP 2FA, recovery email verification, and first-run agreement handling
  - Add batch account setup from `users.csv`
  - Add Camoufox download progress and proxy support
  - Add UI diagnostics for login timeout/debugging

  ## CSV format
  ```csv
  email,password,recovery_email,totp_secret
  ```

  ## Manual test

  Create a local `users.csv` in the project root:

  ```csv
  email,password,recovery_email,totp_secret
  your-test-account@gmail.com,your-password,your-recovery-email@example.com,BASE32TOTPSECRET
  ```

  Run single-account automation:

  ```bash
  npm run setup-auth -- --non-interactive --account 1 --headless --debug-ui --login-timeout-ms 300000
  ```

  Or run batch automation:

  ```bash
  npm run setup-auth-batch -- --accounts 1 --headless --debug-ui --continue-on-error --login-timeout-ms 300000
  ```

  For debugging anti-bot / extra verification pages, use headed mode:

  ```bash
  npm run setup-auth-batch -- --accounts 1 --headed --debug-ui --continue-on-error --login-timeout-ms 300000
  ```

  Expected result:

  - The script auto-fills email and password.
  - If TOTP is available, it fills the 6-digit code.
  - If Google asks to confirm recovery email, it selects that option and fills `recovery_email`.
  - If AI Studio first-run terms appear, it tries to accept them automatically.
  - A valid auth file is saved under `configs/auth/auth-N.json`.