### PR TITLE
fix: enhance immediate status retry logic and account tracking in RequestHandler

### DIFF
--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -977,7 +977,7 @@ class RequestHandler {
 
                 await this._handleNonStreamResponse(proxyRequest, messageQueue, req, res);
             } catch (error) {
-                this._handleRequestError(error, res, "openai", requestId);
+                this._handleRequestError(error, res, "gemini", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -3273,7 +3273,7 @@ class RequestHandler {
 
             this.logger.debug(`[Request] Complete non-stream response sent to client.`);
         } catch (error) {
-            this._handleRequestError(error, res, "openai", proxyRequest.request_id);
+            this._handleRequestError(error, res, "gemini", proxyRequest.request_id);
         }
     }
 

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -1051,7 +1051,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] OpenAI request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(res, 400, "Invalid OpenAI request format.");
+                return this._sendErrorResponse(res, 400, "Invalid OpenAI request format.", "openai");
             }
 
             const effectiveStreamMode = modelStreamingMode || systemStreamMode;
@@ -1150,7 +1150,7 @@ class RequestHandler {
                         });
 
                         // Send standard HTTP error response
-                        this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message);
+                        this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message, "openai");
 
                         // Avoid switching account if the error is just a connection reset
                         if (!skipFinalFailureSwitch && !this._isConnectionResetError(initialMessage)) {
@@ -1216,7 +1216,12 @@ class RequestHandler {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
                                 this._handleRequestError(result.error, res, "openai", requestId);
                             } else {
-                                this._sendErrorResponse(res, result.error.status || 500, result.error.message);
+                                this._sendErrorResponse(
+                                    res,
+                                    result.error.status || 500,
+                                    result.error.message,
+                                    "openai"
+                                );
                             }
 
                             // Avoid switching account if the error is just a connection reset
@@ -1467,7 +1472,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] OpenAI Response request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.");
+                return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.", "response_api");
             }
 
             const effectiveStreamMode = modelStreamingMode || systemStreamMode;
@@ -1567,7 +1572,12 @@ class RequestHandler {
                         });
 
                         // Send standard HTTP error response
-                        this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message);
+                        this._sendErrorResponse(
+                            res,
+                            initialMessage.status || 500,
+                            initialMessage.message,
+                            "response_api"
+                        );
 
                         // Avoid switching account if the error is just a connection reset
                         if (!skipFinalFailureSwitch && !this._isConnectionResetError(initialMessage)) {
@@ -1640,7 +1650,12 @@ class RequestHandler {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
                                 this._handleRequestError(result.error, res, "response_api", requestId);
                             } else {
-                                this._sendErrorResponse(res, result.error.status || 500, result.error.message);
+                                this._sendErrorResponse(
+                                    res,
+                                    result.error.status || 500,
+                                    result.error.message,
+                                    "response_api"
+                                );
                             }
 
                             // Avoid switching account if the error is just a connection reset
@@ -1823,7 +1838,7 @@ class RequestHandler {
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
                     sendError: (status, message) =>
-                        this._sendClaudeErrorResponse(res, status, "overloaded_error", message),
+                        this._sendErrorResponse(res, status, message, "claude", "overloaded_error"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -1862,11 +1877,12 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] Claude request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendClaudeErrorResponse(
+                return this._sendErrorResponse(
                     res,
                     400,
-                    "invalid_request_error",
-                    "Invalid Claude request format."
+                    "Invalid Claude request format.",
+                    "claude",
+                    "invalid_request_error"
                 );
             }
 
@@ -1965,11 +1981,12 @@ class RequestHandler {
                         this._logFinalRequestFailure(initialMessage, "Claude real stream", requestId, {
                             afterRetries: false,
                         });
-                        this._sendClaudeErrorResponse(
+                        this._sendErrorResponse(
                             res,
                             initialMessage.status || 500,
-                            "api_error",
-                            initialMessage.message
+                            initialMessage.message,
+                            "claude",
+                            "api_error"
                         );
                         if (!skipFinalFailureSwitch && !this._isConnectionResetError(initialMessage)) {
                             await this.authSwitcher.handleRequestFailureAndSwitch(initialMessage, null);
@@ -2024,13 +2041,14 @@ class RequestHandler {
                             if (connectionMaintainer) clearTimeout(connectionMaintainer);
                             if (isClaudeStream && res.headersSent) {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
-                                this._handleClaudeRequestError(result.error, res, requestId);
+                                this._handleRequestError(result.error, res, "claude", requestId);
                             } else {
-                                this._sendClaudeErrorResponse(
+                                this._sendErrorResponse(
                                     res,
                                     result.error.status || 500,
-                                    "api_error",
-                                    result.error.message
+                                    result.error.message,
+                                    "claude",
+                                    "api_error"
                                 );
                             }
                             if (!result.error.skipAccountSwitch && !this._isConnectionResetError(result.error)) {
@@ -2146,7 +2164,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleClaudeRequestError(error, res, requestId);
+                this._handleRequestError(error, res, "claude", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -2194,7 +2212,7 @@ class RequestHandler {
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
                     sendError: (status, message) =>
-                        this._sendClaudeErrorResponse(res, status, "overloaded_error", message),
+                        this._sendErrorResponse(res, status, message, "claude", "overloaded_error"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -2216,11 +2234,12 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] Claude request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendClaudeErrorResponse(
+                return this._sendErrorResponse(
                     res,
                     400,
-                    "invalid_request_error",
-                    "Invalid Claude request format."
+                    "Invalid Claude request format.",
+                    "claude",
+                    "invalid_request_error"
                 );
             }
 
@@ -2272,7 +2291,7 @@ class RequestHandler {
                     this.logger.error(
                         `❌ [Request] Received error from browser, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
                     );
-                    this._sendClaudeErrorResponse(res, response.status || 500, "api_error", response.message);
+                    this._sendErrorResponse(res, response.status || 500, response.message, "claude", "api_error");
                     if (!this._isConnectionResetError(response)) {
                         await this.authSwitcher.handleRequestFailureAndSwitch(response, null);
                     }
@@ -2292,7 +2311,7 @@ class RequestHandler {
                         if (message.event_type === "error") {
                             this.logger.error(`❌ [Request] Error received during count tokens: ${message.message}`);
                             this._markTrackedResponseError(res, message.message, 500);
-                            return this._sendClaudeErrorResponse(res, 500, "api_error", message.message);
+                            return this._sendErrorResponse(res, 500, message.message, "claude", "api_error");
                         }
                         if (message.data) fullBody += message.data;
                     }
@@ -2319,7 +2338,7 @@ class RequestHandler {
                     `✅ [Request] Response completed (Claude count_tokens, input tokens: ${totalTokens}), request ID: ${requestId}`
                 );
             } catch (error) {
-                this._handleClaudeRequestError(error, res, requestId);
+                this._handleRequestError(error, res, "claude", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -2378,7 +2397,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] OpenAI Response input_tokens translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.");
+                return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.", "response_api");
             }
 
             // Gemini countTokens accepts either:
@@ -2428,7 +2447,7 @@ class RequestHandler {
                         `❌ [Request] Received error from browser for input_tokens, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
                     );
 
-                    this._sendErrorResponse(res, response.status || 500, response.message);
+                    this._sendErrorResponse(res, response.status || 500, response.message, "response_api");
 
                     // Avoid switching account if the error is just a connection reset
                     if (!this._isConnectionResetError(response)) {
@@ -2456,7 +2475,7 @@ class RequestHandler {
                                 `❌ [Request] Error received during input_tokens count: ${message.message}`
                             );
                             this._markTrackedResponseError(res, message.message, 500);
-                            this._sendErrorResponse(res, 500, message.message);
+                            this._sendErrorResponse(res, 500, message.message, "response_api");
                             return;
                         }
                         if (message.data) fullBody += message.data;
@@ -2469,7 +2488,7 @@ class RequestHandler {
                     geminiResponse = JSON.parse(fullBody || response.body);
                 } catch (parseError) {
                     this.logger.error(`❌ [Request] Failed to parse countTokens response: ${parseError.message}`);
-                    this._sendErrorResponse(res, 500, "Failed to parse backend response");
+                    this._sendErrorResponse(res, 500, "Failed to parse backend response", "response_api");
                     return;
                 }
 
@@ -2594,7 +2613,7 @@ class RequestHandler {
 
             if (message.event_type === "error") {
                 this.logger.error(`❌ [Adapter] Error during Claude non-stream conversion: ${message.message}`);
-                this._sendClaudeErrorResponse(res, 500, "api_error", message.message);
+                this._sendErrorResponse(res, 500, message.message, "claude", "api_error");
                 return;
             }
 
@@ -2610,112 +2629,7 @@ class RequestHandler {
             this.logger.info(`✅ [Request] Response completed (Claude non-stream), request ID: ${requestId}`);
         } catch (e) {
             this.logger.error(`❌ [Adapter] Failed to parse response for Claude: ${e.message}`);
-            this._sendClaudeErrorResponse(res, 500, "api_error", "Failed to parse backend response");
-        }
-    }
-
-    _sendClaudeErrorResponse(res, status, errorType, message) {
-        if (!res.headersSent) {
-            this._markTrackedResponseError(res, message, status || 500);
-            res.status(status)
-                .type("application/json")
-                .send(
-                    JSON.stringify({
-                        error: {
-                            message,
-                            type: errorType,
-                        },
-                        type: "error",
-                    })
-                );
-        }
-    }
-
-    _handleClaudeRequestError(error, res, requestId = null) {
-        // Normalize error message to handle non-Error objects and missing/non-string messages
-        const errorMsg = String(error?.message ?? error);
-        const requestIdSuffix = requestId ? `, request ID: ${requestId}` : "";
-
-        // Check if this is a client disconnect - if so, just log and return
-        if (this._isConnectionResetError(error)) {
-            const isClientDisconnect = error.reason === "client_disconnect" || !this._isResponseWritable(res);
-            if (isClientDisconnect) {
-                this._markTrackedClientAbort(res, errorMsg);
-                this.logger.info(
-                    `[Request] Request terminated: Queue closed (${error.reason || "connection_lost"})${requestIdSuffix}`
-                );
-                if (!res.writableEnded) {
-                    try {
-                        res.end();
-                    } catch (e) {
-                        // Ignore end errors for disconnected clients
-                    }
-                }
-                return;
-            }
-        }
-
-        if (res.headersSent) {
-            this.logger.error(
-                `❌ [Request] Claude request error (headers already sent): ${errorMsg}${requestIdSuffix}`
-            );
-
-            // Try to send error in SSE format if response is still writable
-            if (this._isResponseWritable(res)) {
-                const contentType = res.getHeader("content-type");
-
-                if (contentType && contentType.includes("text/event-stream")) {
-                    try {
-                        let errorType = "api_error";
-                        let errorMessage = `Processing failed: ${errorMsg}`;
-                        let errorStatus = 500;
-
-                        // Use precise error type checking instead of string matching
-                        if (error instanceof QueueTimeoutError || error.code === "QUEUE_TIMEOUT") {
-                            errorType = "timeout_error";
-                            errorMessage = `Stream timeout: ${errorMsg}`;
-                            errorStatus = 504;
-                        } else if (this._isConnectionResetError(error)) {
-                            errorType = "overloaded_error";
-                            errorMessage = `Service unavailable: ${errorMsg}`;
-                            errorStatus = 503;
-                        }
-
-                        this._markTrackedResponseError(res, errorMessage, errorStatus);
-
-                        res.write(
-                            `event: error\ndata: ${JSON.stringify({
-                                error: {
-                                    message: errorMessage,
-                                    type: errorType,
-                                },
-                                type: "error",
-                            })}\n\n`
-                        );
-                        this.logger.info("[Request] Claude error event sent to SSE stream");
-                    } catch (writeError) {
-                        this.logger.error(
-                            `❌ [Request] Failed to write error to Claude stream: ${writeError.message}${requestIdSuffix}`
-                        );
-                    }
-                }
-            }
-
-            if (!res.writableEnded) res.end();
-        } else {
-            this.logger.error(`❌ [Request] Claude request error: ${errorMsg}${requestIdSuffix}`);
-            let status = 500;
-            let errorType = "api_error";
-            // Use precise error type checking instead of string matching
-            if (error instanceof QueueTimeoutError || error.code === "QUEUE_TIMEOUT") {
-                status = 504;
-                errorType = "timeout_error";
-            } else if (this._isConnectionResetError(error)) {
-                status = 503;
-                errorType = "overloaded_error";
-                this.logger.info(`[Request] Queue closed, returning 503 Service Unavailable.`);
-            }
-            this._sendClaudeErrorResponse(res, status, errorType, `Proxy error: ${errorMsg}`);
+            this._sendErrorResponse(res, 500, "Failed to parse backend response", "claude", "api_error");
         }
     }
 
@@ -3661,7 +3575,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] Error during OpenAI Response API non-stream conversion: ${message.message}`
                 );
-                this._sendErrorResponse(res, 500, message.message);
+                this._sendErrorResponse(res, 500, message.message, "response_api");
                 return;
             }
 
@@ -3684,7 +3598,7 @@ class RequestHandler {
             );
         } catch (e) {
             this.logger.error(`❌ [Adapter] Failed to parse response for OpenAI Response API: ${e.message}`);
-            this._sendErrorResponse(res, 500, "Failed to parse backend response");
+            this._sendErrorResponse(res, 500, "Failed to parse backend response", "response_api");
         }
     }
 
@@ -3701,7 +3615,7 @@ class RequestHandler {
 
             if (message.event_type === "error") {
                 this.logger.error(`❌ [Adapter] Error during OpenAI non-stream conversion: ${message.message}`);
-                this._sendErrorResponse(res, 500, message.message);
+                this._sendErrorResponse(res, 500, message.message, "openai");
                 return;
             }
 
@@ -3718,7 +3632,7 @@ class RequestHandler {
             this.logger.info(`✅ [Request] Response completed (OpenAI non-stream), request ID: ${requestId}`);
         } catch (e) {
             this.logger.error(`❌ [Adapter] Failed to parse response for OpenAI: ${e.message}`);
-            this._sendErrorResponse(res, 500, "Failed to parse backend response");
+            this._sendErrorResponse(res, 500, "Failed to parse backend response", "openai");
         }
     }
 
@@ -3903,30 +3817,63 @@ class RequestHandler {
         } else {
             this.logger.error(`❌ [Request] Request processing error: ${errorMsg}${requestIdSuffix}`);
             let status = 500;
+            let errorType = "api_error";
             // Use precise error type checking instead of string matching
             if (error instanceof QueueTimeoutError || error.code === "QUEUE_TIMEOUT") {
                 status = 504;
+                errorType = "timeout_error";
             } else if (this._isConnectionResetError(error)) {
                 status = 503;
+                errorType = "service_unavailable";
                 this.logger.info(`[Request] Queue closed, returning 503 Service Unavailable.`);
             }
-            this._sendErrorResponse(res, status, `Proxy error: ${errorMsg}`);
+            this._sendErrorResponse(res, status, `Proxy error: ${errorMsg}`, format, errorType);
         }
     }
 
-    _sendErrorResponse(res, status, message) {
+    _sendErrorResponse(res, status, message, format = "gemini", errorType = null) {
         if (!res.headersSent) {
-            this._markTrackedResponseError(res, message, status || 500);
-            const errorPayload = {
-                error: {
-                    code: status || 500,
-                    message,
-                    status: "SERVICE_UNAVAILABLE",
-                },
-            };
-            res.status(status || 500)
-                .type("application/json")
-                .send(JSON.stringify(errorPayload));
+            const statusCode = Number(status) || 500;
+            const resolvedErrorType = errorType || "api_error";
+            let errorPayload;
+
+            if (format === "claude") {
+                errorPayload = {
+                    error: {
+                        message,
+                        type: resolvedErrorType,
+                    },
+                    type: "error",
+                };
+            } else if (format === "openai") {
+                errorPayload = {
+                    error: {
+                        code: statusCode,
+                        message,
+                        type: resolvedErrorType,
+                    },
+                };
+            } else if (format === "response_api") {
+                errorPayload = {
+                    error: {
+                        code: resolvedErrorType,
+                        message,
+                        param: null,
+                        type: resolvedErrorType,
+                    },
+                };
+            } else {
+                errorPayload = {
+                    error: {
+                        code: statusCode,
+                        message,
+                        status: "SERVICE_UNAVAILABLE",
+                    },
+                };
+            }
+
+            this._markTrackedResponseError(res, message, statusCode);
+            res.status(statusCode).type("application/json").send(JSON.stringify(errorPayload));
         }
     }
 

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -92,6 +92,25 @@ class RequestHandler {
         return fallback;
     }
 
+    _setResponseApiFormat(res, apiFormat) {
+        if (!res || !apiFormat) return;
+        res.__proxyApiFormat = apiFormat;
+    }
+
+    _resolveErrorFormat(res) {
+        const trackedFormat = res?.__proxyApiFormat;
+        if (trackedFormat && trackedFormat !== "upload") return trackedFormat;
+        return "gemini";
+    }
+
+    _getDefaultErrorType(format, statusCode) {
+        if (statusCode === 504) return "timeout_error";
+        if (statusCode === 503) {
+            return format === "claude" ? "overloaded_error" : "service_unavailable";
+        }
+        return "api_error";
+    }
+
     _startTrackedRequest(requestId, req, meta = {}) {
         const usageStatsService = this._getUsageStatsService();
         if (!usageStatsService) return;
@@ -232,10 +251,10 @@ class RequestHandler {
      * Handle queue closed error in real streaming mode with proper SSE error response
      * @param {Error} error - The error object (QueueClosedError)
      * @param {Object} res - Express response object
-     * @param {string} format - Response format ('openai', 'response_api', 'claude', or 'gemini')
      * @returns {boolean} true if error was handled, false otherwise
      */
-    _handleRealStreamQueueClosedError(error, res, format) {
+    _handleRealStreamQueueClosedError(error, res) {
+        const format = this._resolveErrorFormat(res);
         const isClientDisconnect = error.reason === "client_disconnect" || !this._isResponseWritable(res);
 
         if (isClientDisconnect) {
@@ -319,10 +338,10 @@ class RequestHandler {
      * Classify and handle fake stream errors
      * @param {Error} error - The error object
      * @param {Object} res - Express response object
-     * @param {string} format - Response format ('openai', 'response_api', 'claude', or 'gemini')
      * @throws {Error} Rethrows unexpected errors for outer handler
      */
-    _handleFakeStreamError(error, res, format) {
+    _handleFakeStreamError(error, res) {
+        const format = this._resolveErrorFormat(res);
         if (!this._isResponseWritable(res)) {
             return; // Client disconnected, no need to send error
         }
@@ -804,6 +823,7 @@ class RequestHandler {
             apiFormat: "gemini",
             requestCategory: this._categorizeRequest(req.path, "request"),
         });
+        this._setResponseApiFormat(res, "gemini");
         res.__proxyResponseStreamMode = null;
 
         try {
@@ -894,7 +914,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleRequestError(error, res, "gemini", requestId);
+                this._handleRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -923,6 +943,7 @@ class RequestHandler {
             requestCategory: "upload",
             streamMode: null,
         });
+        this._setResponseApiFormat(res, "upload");
 
         try {
             // Check current account's browser connection
@@ -977,7 +998,7 @@ class RequestHandler {
 
                 await this._handleNonStreamResponse(proxyRequest, messageQueue, req, res);
             } catch (error) {
-                this._handleRequestError(error, res, "gemini", requestId);
+                this._handleRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -996,6 +1017,7 @@ class RequestHandler {
             requestCategory: "generation",
             streamMode: req.body.stream === true ? this.serverSystem.streamingMode : null,
         });
+        this._setResponseApiFormat(res, "openai");
         res.__proxyResponseStreamMode = null;
 
         try {
@@ -1016,7 +1038,7 @@ class RequestHandler {
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
                     sendError: (status, message) =>
-                        this._sendErrorResponse(res, status, message, "openai", "service_unavailable"),
+                        this._sendErrorResponse(res, status, message, "service_unavailable"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -1054,13 +1076,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] OpenAI request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(
-                    res,
-                    400,
-                    "Invalid OpenAI request format.",
-                    "openai",
-                    "invalid_request_error"
-                );
+                return this._sendErrorResponse(res, 400, "Invalid OpenAI request format.", "invalid_request_error");
             }
 
             const effectiveStreamMode = modelStreamingMode || systemStreamMode;
@@ -1159,7 +1175,7 @@ class RequestHandler {
                         });
 
                         // Send standard HTTP error response
-                        this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message, "openai");
+                        this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message);
 
                         // Avoid switching account if the error is just a connection reset
                         if (!skipFinalFailureSwitch && !this._isConnectionResetError(initialMessage)) {
@@ -1223,14 +1239,9 @@ class RequestHandler {
                             if (connectionMaintainer) clearTimeout(connectionMaintainer);
                             if (isOpenAIStream && res.headersSent) {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
-                                this._handleRequestError(result.error, res, "openai", requestId);
+                                this._handleRequestError(result.error, res, requestId);
                             } else {
-                                this._sendErrorResponse(
-                                    res,
-                                    result.error.status || 500,
-                                    result.error.message,
-                                    "openai"
-                                );
+                                this._sendErrorResponse(res, result.error.status || 500, result.error.message);
                             }
 
                             // Avoid switching account if the error is just a connection reset
@@ -1335,7 +1346,7 @@ class RequestHandler {
                                 );
                             } catch (error) {
                                 // Classify error type and send appropriate response
-                                this._handleFakeStreamError(error, res, "openai");
+                                this._handleFakeStreamError(error, res);
                             }
                         } else {
                             // Non-stream
@@ -1349,7 +1360,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleRequestError(error, res, "openai", requestId);
+                this._handleRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -1377,6 +1388,7 @@ class RequestHandler {
             requestCategory: "generation",
             streamMode: req.body.stream === true ? this.serverSystem.streamingMode : null,
         });
+        this._setResponseApiFormat(res, "response_api");
         res.__proxyResponseStreamMode = null;
 
         try {
@@ -1397,7 +1409,7 @@ class RequestHandler {
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
                     sendError: (status, message) =>
-                        this._sendErrorResponse(res, status, message, "response_api", "service_unavailable"),
+                        this._sendErrorResponse(res, status, message, "service_unavailable"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -1488,7 +1500,6 @@ class RequestHandler {
                     res,
                     400,
                     "Invalid OpenAI Response request format.",
-                    "response_api",
                     "invalid_request_error"
                 );
             }
@@ -1590,12 +1601,7 @@ class RequestHandler {
                         });
 
                         // Send standard HTTP error response
-                        this._sendErrorResponse(
-                            res,
-                            initialMessage.status || 500,
-                            initialMessage.message,
-                            "response_api"
-                        );
+                        this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message);
 
                         // Avoid switching account if the error is just a connection reset
                         if (!skipFinalFailureSwitch && !this._isConnectionResetError(initialMessage)) {
@@ -1666,14 +1672,9 @@ class RequestHandler {
                             if (connectionMaintainer) clearTimeout(connectionMaintainer);
                             if (isOpenAIStream && res.headersSent) {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
-                                this._handleRequestError(result.error, res, "response_api", requestId);
+                                this._handleRequestError(result.error, res, requestId);
                             } else {
-                                this._sendErrorResponse(
-                                    res,
-                                    result.error.status || 500,
-                                    result.error.message,
-                                    "response_api"
-                                );
+                                this._sendErrorResponse(res, result.error.status || 500, result.error.message);
                             }
 
                             // Avoid switching account if the error is just a connection reset
@@ -1788,7 +1789,7 @@ class RequestHandler {
                                 );
                             } catch (error) {
                                 // Classify error type and send appropriate response
-                                this._handleFakeStreamError(error, res, "response_api");
+                                this._handleFakeStreamError(error, res);
                             }
                         } else {
                             // Non-stream
@@ -1808,7 +1809,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleRequestError(error, res, "response_api", requestId);
+                this._handleRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -1836,6 +1837,7 @@ class RequestHandler {
             requestCategory: "generation",
             streamMode: req.body.stream === true ? this.serverSystem.streamingMode : null,
         });
+        this._setResponseApiFormat(res, "claude");
         res.__proxyResponseStreamMode = null;
 
         try {
@@ -1855,8 +1857,7 @@ class RequestHandler {
             // Wait for system to become ready if it's busy
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
-                    sendError: (status, message) =>
-                        this._sendErrorResponse(res, status, message, "claude", "overloaded_error"),
+                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "overloaded_error"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -1895,13 +1896,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] Claude request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(
-                    res,
-                    400,
-                    "Invalid Claude request format.",
-                    "claude",
-                    "invalid_request_error"
-                );
+                return this._sendErrorResponse(res, 400, "Invalid Claude request format.", "invalid_request_error");
             }
 
             const effectiveStreamMode = modelStreamingMode || systemStreamMode;
@@ -1999,13 +1994,7 @@ class RequestHandler {
                         this._logFinalRequestFailure(initialMessage, "Claude real stream", requestId, {
                             afterRetries: false,
                         });
-                        this._sendErrorResponse(
-                            res,
-                            initialMessage.status || 500,
-                            initialMessage.message,
-                            "claude",
-                            "api_error"
-                        );
+                        this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message, "api_error");
                         if (!skipFinalFailureSwitch && !this._isConnectionResetError(initialMessage)) {
                             await this.authSwitcher.handleRequestFailureAndSwitch(initialMessage, null);
                         } else if (skipFinalFailureSwitch) {
@@ -2059,13 +2048,12 @@ class RequestHandler {
                             if (connectionMaintainer) clearTimeout(connectionMaintainer);
                             if (isClaudeStream && res.headersSent) {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
-                                this._handleRequestError(result.error, res, "claude", requestId);
+                                this._handleRequestError(result.error, res, requestId);
                             } else {
                                 this._sendErrorResponse(
                                     res,
                                     result.error.status || 500,
                                     result.error.message,
-                                    "claude",
                                     "api_error"
                                 );
                             }
@@ -2168,7 +2156,7 @@ class RequestHandler {
                                 );
                             } catch (error) {
                                 // Classify error type and send appropriate response
-                                this._handleFakeStreamError(error, res, "claude");
+                                this._handleFakeStreamError(error, res);
                             }
                         } else {
                             // Non-stream
@@ -2182,7 +2170,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleRequestError(error, res, "claude", requestId);
+                this._handleRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -2211,6 +2199,7 @@ class RequestHandler {
             requestCategory: "count_tokens",
             streamMode: null,
         });
+        this._setResponseApiFormat(res, "claude");
 
         try {
             // Check current account's browser connection
@@ -2229,8 +2218,7 @@ class RequestHandler {
             // Wait for system to become ready if it's busy
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
-                    sendError: (status, message) =>
-                        this._sendErrorResponse(res, status, message, "claude", "overloaded_error"),
+                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "overloaded_error"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -2252,13 +2240,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] Claude request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(
-                    res,
-                    400,
-                    "Invalid Claude request format.",
-                    "claude",
-                    "invalid_request_error"
-                );
+                return this._sendErrorResponse(res, 400, "Invalid Claude request format.", "invalid_request_error");
             }
 
             // Build countTokens request
@@ -2309,7 +2291,7 @@ class RequestHandler {
                     this.logger.error(
                         `❌ [Request] Received error from browser, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
                     );
-                    this._sendErrorResponse(res, response.status || 500, response.message, "claude", "api_error");
+                    this._sendErrorResponse(res, response.status || 500, response.message, "api_error");
                     if (!this._isConnectionResetError(response)) {
                         await this.authSwitcher.handleRequestFailureAndSwitch(response, null);
                     }
@@ -2329,7 +2311,7 @@ class RequestHandler {
                         if (message.event_type === "error") {
                             this.logger.error(`❌ [Request] Error received during count tokens: ${message.message}`);
                             this._markTrackedResponseError(res, message.message, 500);
-                            return this._sendErrorResponse(res, 500, message.message, "claude", "api_error");
+                            return this._sendErrorResponse(res, 500, message.message, "api_error");
                         }
                         if (message.data) fullBody += message.data;
                     }
@@ -2356,7 +2338,7 @@ class RequestHandler {
                     `✅ [Request] Response completed (Claude count_tokens, input tokens: ${totalTokens}), request ID: ${requestId}`
                 );
             } catch (error) {
-                this._handleRequestError(error, res, "claude", requestId);
+                this._handleRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -2377,6 +2359,7 @@ class RequestHandler {
             requestCategory: "count_tokens",
             streamMode: null,
         });
+        this._setResponseApiFormat(res, "response_api");
 
         try {
             // Check current account's browser connection
@@ -2396,7 +2379,7 @@ class RequestHandler {
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
                     sendError: (status, message) =>
-                        this._sendErrorResponse(res, status, message, "response_api", "service_unavailable"),
+                        this._sendErrorResponse(res, status, message, "service_unavailable"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -2422,7 +2405,6 @@ class RequestHandler {
                     res,
                     400,
                     "Invalid OpenAI Response request format.",
-                    "response_api",
                     "invalid_request_error"
                 );
             }
@@ -2474,7 +2456,7 @@ class RequestHandler {
                         `❌ [Request] Received error from browser for input_tokens, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
                     );
 
-                    this._sendErrorResponse(res, response.status || 500, response.message, "response_api");
+                    this._sendErrorResponse(res, response.status || 500, response.message);
 
                     // Avoid switching account if the error is just a connection reset
                     if (!this._isConnectionResetError(response)) {
@@ -2502,7 +2484,7 @@ class RequestHandler {
                                 `❌ [Request] Error received during input_tokens count: ${message.message}`
                             );
                             this._markTrackedResponseError(res, message.message, 500);
-                            this._sendErrorResponse(res, 500, message.message, "response_api");
+                            this._sendErrorResponse(res, 500, message.message);
                             return;
                         }
                         if (message.data) fullBody += message.data;
@@ -2515,7 +2497,7 @@ class RequestHandler {
                     geminiResponse = JSON.parse(fullBody || response.body);
                 } catch (parseError) {
                     this.logger.error(`❌ [Request] Failed to parse countTokens response: ${parseError.message}`);
-                    this._sendErrorResponse(res, 500, "Failed to parse backend response", "response_api");
+                    this._sendErrorResponse(res, 500, "Failed to parse backend response");
                     return;
                 }
 
@@ -2537,7 +2519,7 @@ class RequestHandler {
                     `✅ [Request] Response completed (OpenAI Response input_tokens, input tokens: ${totalTokens}), request ID: ${requestId}`
                 );
             } catch (error) {
-                this._handleRequestError(error, res, "response_api", requestId);
+                this._handleRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -2618,7 +2600,7 @@ class RequestHandler {
             // Only handle connection reset errors here (client disconnect)
             // Let other errors (timeout, parsing, logic errors) propagate to outer catch
             if (this._isConnectionResetError(error)) {
-                this._handleRealStreamQueueClosedError(error, res, "claude");
+                this._handleRealStreamQueueClosedError(error, res);
                 return;
             }
 
@@ -2640,7 +2622,7 @@ class RequestHandler {
 
             if (message.event_type === "error") {
                 this.logger.error(`❌ [Adapter] Error during Claude non-stream conversion: ${message.message}`);
-                this._sendErrorResponse(res, 500, message.message, "claude", "api_error");
+                this._sendErrorResponse(res, 500, message.message, "api_error");
                 return;
             }
 
@@ -2656,7 +2638,7 @@ class RequestHandler {
             this.logger.info(`✅ [Request] Response completed (Claude non-stream), request ID: ${requestId}`);
         } catch (e) {
             this.logger.error(`❌ [Adapter] Failed to parse response for Claude: ${e.message}`);
-            this._sendErrorResponse(res, 500, "Failed to parse backend response", "claude", "api_error");
+            this._sendErrorResponse(res, 500, "Failed to parse backend response", "api_error");
         }
     }
 
@@ -2700,7 +2682,7 @@ class RequestHandler {
                     this._logFinalRequestFailure(result.error, "Gemini fake stream", proxyRequest.request_id);
                     // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
                     if (res.headersSent) {
-                        this._handleRequestError(result.error, res, "gemini", proxyRequest.request_id);
+                        this._handleRequestError(result.error, res, proxyRequest.request_id);
                     } else {
                         this._sendErrorResponse(res, result.error.status || 500, result.error.message);
                     }
@@ -2756,7 +2738,7 @@ class RequestHandler {
                         );
                         this._markTrackedResponseError(res, message.message, 500);
                         hadStreamError = true;
-                        this._handleRequestError({ message: message.message }, res, "gemini", proxyRequest.request_id);
+                        this._handleRequestError({ message: message.message }, res, proxyRequest.request_id);
                         break;
                     }
 
@@ -2769,7 +2751,7 @@ class RequestHandler {
                 // Don't attempt to write if it's a connection reset or if response is destroyed
                 if (!this._isConnectionResetError(error)) {
                     // Classify error type and send appropriate response
-                    this._handleFakeStreamError(error, res, "gemini");
+                    this._handleFakeStreamError(error, res);
                 } else {
                     this.logger.debug(
                         "[Request] Gemini pseudo-stream interrupted by connection reset, skipping error write"
@@ -2937,7 +2919,7 @@ class RequestHandler {
                 `✅ [Request] Response completed (Gemini pseudo-stream, reason: ${finishReason}), request ID: ${proxyRequest.request_id}`
             );
         } catch (error) {
-            this._handleRequestError(error, res, "gemini", proxyRequest.request_id);
+            this._handleRequestError(error, res, proxyRequest.request_id);
         } finally {
             clearTimeout(connectionMaintainer);
             if (!res.writableEnded) {
@@ -3112,10 +3094,10 @@ class RequestHandler {
         } catch (error) {
             // Handle queue closed errors (account switch, context closed, etc.)
             if (this._isConnectionResetError(error)) {
-                this._handleRealStreamQueueClosedError(error, res, "gemini");
+                this._handleRealStreamQueueClosedError(error, res);
             } else if (error instanceof QueueTimeoutError || error.code === "QUEUE_TIMEOUT") {
                 // Keep behavior consistent with other interfaces: treat missing stream chunks as a timeout error.
-                this._handleRequestError(error, res, "gemini", proxyRequest.request_id);
+                this._handleRequestError(error, res, proxyRequest.request_id);
             } else {
                 // Unexpected error - rethrow to outer handler
                 throw error;
@@ -3214,7 +3196,7 @@ class RequestHandler {
 
             this.logger.debug(`[Request] Complete non-stream response sent to client.`);
         } catch (error) {
-            this._handleRequestError(error, res, "gemini", proxyRequest.request_id);
+            this._handleRequestError(error, res, proxyRequest.request_id);
         }
     }
 
@@ -3502,7 +3484,7 @@ class RequestHandler {
             // Only handle connection reset errors here (client disconnect / queue closed).
             // Let other errors (timeout, parsing, logic errors) propagate to the outer catch.
             if (this._isConnectionResetError(error)) {
-                this._handleRealStreamQueueClosedError(error, res, "response_api");
+                this._handleRealStreamQueueClosedError(error, res);
                 return;
             }
 
@@ -3578,7 +3560,7 @@ class RequestHandler {
             // Only handle connection reset errors here (client disconnect)
             // Let other errors (timeout, parsing, logic errors) propagate to outer catch
             if (this._isConnectionResetError(error)) {
-                this._handleRealStreamQueueClosedError(error, res, "openai");
+                this._handleRealStreamQueueClosedError(error, res);
                 return;
             }
 
@@ -3602,7 +3584,7 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] Error during OpenAI Response API non-stream conversion: ${message.message}`
                 );
-                this._sendErrorResponse(res, 500, message.message, "response_api");
+                this._sendErrorResponse(res, 500, message.message);
                 return;
             }
 
@@ -3625,7 +3607,7 @@ class RequestHandler {
             );
         } catch (e) {
             this.logger.error(`❌ [Adapter] Failed to parse response for OpenAI Response API: ${e.message}`);
-            this._sendErrorResponse(res, 500, "Failed to parse backend response", "response_api");
+            this._sendErrorResponse(res, 500, "Failed to parse backend response");
         }
     }
 
@@ -3642,7 +3624,7 @@ class RequestHandler {
 
             if (message.event_type === "error") {
                 this.logger.error(`❌ [Adapter] Error during OpenAI non-stream conversion: ${message.message}`);
-                this._sendErrorResponse(res, 500, message.message, "openai");
+                this._sendErrorResponse(res, 500, message.message);
                 return;
             }
 
@@ -3659,7 +3641,7 @@ class RequestHandler {
             this.logger.info(`✅ [Request] Response completed (OpenAI non-stream), request ID: ${requestId}`);
         } catch (e) {
             this.logger.error(`❌ [Adapter] Failed to parse response for OpenAI: ${e.message}`);
-            this._sendErrorResponse(res, 500, "Failed to parse backend response", "openai");
+            this._sendErrorResponse(res, 500, "Failed to parse backend response");
         }
     }
 
@@ -3710,7 +3692,8 @@ class RequestHandler {
         });
     }
 
-    _handleRequestError(error, res, format = "openai", requestId = null) {
+    _handleRequestError(error, res, requestId = null) {
+        const format = this._resolveErrorFormat(res);
         // Normalize error message to handle non-Error objects and missing/non-string messages
         const errorMsg = String(error?.message ?? error);
         const requestIdSuffix = requestId ? `, request ID: ${requestId}` : "";
@@ -3821,12 +3804,15 @@ class RequestHandler {
                     // Request-scoped fake stream mode - try to send an SSE-style error chunk
                     try {
                         let status = 500;
+                        let errorType = "api_error";
                         if (error instanceof QueueTimeoutError || error.code === "QUEUE_TIMEOUT") {
                             status = 504;
+                            errorType = "timeout_error";
                         } else if (this._isConnectionResetError(error)) {
                             status = 503;
+                            errorType = this._getDefaultErrorType(format, status);
                         }
-                        this._sendErrorChunkToClient(res, `Processing failed: ${errorMsg}`, status);
+                        this._sendErrorChunkToClient(res, `Processing failed: ${errorMsg}`, status, errorType);
                     } catch (writeError) {
                         const writeErrorMsg = String(writeError?.message ?? writeError);
                         this.logger.error(
@@ -3854,17 +3840,18 @@ class RequestHandler {
                 errorType = format === "claude" ? "overloaded_error" : "service_unavailable";
                 this.logger.info(`[Request] Queue closed, returning 503 Service Unavailable.`);
             }
-            this._sendErrorResponse(res, status, `Proxy error: ${errorMsg}`, format, errorType);
+            this._sendErrorResponse(res, status, `Proxy error: ${errorMsg}`, errorType);
         }
     }
 
-    _sendErrorResponse(res, status, message, format = "gemini", errorType = null) {
+    _sendErrorResponse(res, status, message, errorType = null) {
         if (!res.headersSent) {
             const statusCode = Number(status) || 500;
-            const resolvedErrorType = errorType || "api_error";
+            const resolvedFormat = this._resolveErrorFormat(res);
+            const resolvedErrorType = errorType || this._getDefaultErrorType(resolvedFormat, statusCode);
             let errorPayload;
 
-            if (format === "claude") {
+            if (resolvedFormat === "claude") {
                 errorPayload = {
                     error: {
                         message,
@@ -3872,7 +3859,7 @@ class RequestHandler {
                     },
                     type: "error",
                 };
-            } else if (format === "openai") {
+            } else if (resolvedFormat === "openai") {
                 errorPayload = {
                     error: {
                         code: statusCode,
@@ -3880,7 +3867,7 @@ class RequestHandler {
                         type: resolvedErrorType,
                     },
                 };
-            } else if (format === "response_api") {
+            } else if (resolvedFormat === "response_api") {
                 errorPayload = {
                     error: {
                         code: resolvedErrorType,
@@ -3912,7 +3899,9 @@ class RequestHandler {
         );
     }
 
-    _sendErrorChunkToClient(res, message, statusCode = 500) {
+    _sendErrorChunkToClient(res, message, statusCode = 500, errorType = null) {
+        const format = this._resolveErrorFormat(res);
+        const resolvedErrorType = errorType || this._getDefaultErrorType(format, statusCode);
         if (!res.headersSent) {
             res.setHeader("Content-Type", "text/event-stream");
             res.setHeader("Cache-Control", "no-cache");
@@ -3922,7 +3911,41 @@ class RequestHandler {
         // Check if response is still writable before attempting to write
         if (this._isResponseWritable(res)) {
             try {
-                res.write(`data: ${JSON.stringify({ error: message })}\n\n`);
+                if (format === "response_api") {
+                    if (res.__responseApiSeq == null) res.__responseApiSeq = 0;
+                    res.__responseApiSeq += 1;
+                    res.write(
+                        `event: error\ndata: ${JSON.stringify({
+                            code: resolvedErrorType,
+                            message,
+                            param: null,
+                            sequence_number: res.__responseApiSeq,
+                            type: "error",
+                        })}\n\n`
+                    );
+                } else if (format === "claude") {
+                    res.write(
+                        `event: error\ndata: ${JSON.stringify({
+                            error: {
+                                message,
+                                type: resolvedErrorType,
+                            },
+                            type: "error",
+                        })}\n\n`
+                    );
+                } else if (format === "openai") {
+                    res.write(
+                        `data: ${JSON.stringify({
+                            error: {
+                                code: statusCode,
+                                message,
+                                type: resolvedErrorType,
+                            },
+                        })}\n\n`
+                    );
+                } else {
+                    res.write(`data: ${JSON.stringify({ error: message })}\n\n`);
+                }
             } catch (writeError) {
                 this.logger.debug(`[Request] Failed to write error chunk to client: ${writeError.message}`);
             }

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -3411,6 +3411,9 @@ class RequestHandler {
                 );
                 // Update tracked authIndex for the new queue
                 currentQueueAuthIndex = this.currentAuthIndex;
+                if (Number.isInteger(currentQueueAuthIndex) && currentQueueAuthIndex >= 0) {
+                    immediateSwitchTracker.attemptedAuthIndices.add(currentQueueAuthIndex);
+                }
 
                 // Wait before the next retry
                 await new Promise(resolve => setTimeout(resolve, this.retryDelay));

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -1763,8 +1763,8 @@ class RequestHandler {
                                 activeQueue,
                                 res,
                                 model,
-                                responseDefaults,
-                                requestId
+                                requestId,
+                                responseDefaults
                             );
                         }
                     } finally {
@@ -3646,7 +3646,7 @@ class RequestHandler {
         }
     }
 
-    async _sendOpenAIResponseAPINonStreamResponse(messageQueue, res, model, responseDefaults = {}, requestId) {
+    async _sendOpenAIResponseAPINonStreamResponse(messageQueue, res, model, requestId, responseDefaults = {}) {
         let fullBody = "";
         let receiving = true;
         while (receiving) {

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -642,9 +642,11 @@ class RequestHandler {
         return this._performImmediateSwitchRetry(errorDetails, requestId, tracker);
     }
 
-    _logFinalRequestFailure(errorDetails, contextLabel = "Request") {
+    _logFinalRequestFailure(errorDetails, contextLabel = "Request", requestId = null, options = {}) {
+        const requestIdSuffix = requestId ? `, request ID: ${requestId}` : "";
+        const failurePhase = options.afterRetries === false ? "failed" : "failed after retries";
         this.logger.error(
-            `[Request] ${contextLabel} failed after retries. Status code: ${errorDetails?.status || 500}, message: ${errorDetails?.message || "Unknown error"}`
+            `❌ [Request] ${contextLabel} ${failurePhase}. Status code: ${errorDetails?.status || 500}, message: ${errorDetails?.message || "Unknown error"}${requestIdSuffix}`
         );
     }
 
@@ -840,7 +842,7 @@ class RequestHandler {
                     const rotationCountText =
                         this.config.switchOnUses > 0 ? `${usageCount}/${this.config.switchOnUses}` : `${usageCount}`;
                     this.logger.info(
-                        `[Request] Generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex})`
+                        `[Request] Google generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex}), request ID: ${requestId}`
                     );
                     if (this.authSwitcher.shouldSwitchByUsage()) {
                         this.needsSwitchingAfterRequest = true;
@@ -892,7 +894,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleRequestError(error, res, "gemini");
+                this._handleRequestError(error, res, "gemini", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -914,7 +916,7 @@ class RequestHandler {
     // Process File Upload requests
     async processUploadRequest(req, res) {
         const requestId = this._generateRequestId();
-        this.logger.info(`[Upload] Processing upload request ${req.method} ${req.path} (ID: ${requestId})`);
+        this.logger.info(`[Upload] Processing upload request ${req.method} ${req.path}, request ID: ${requestId}`);
         this._startTrackedRequest(requestId, req, {
             apiFormat: "upload",
             isStreaming: false,
@@ -975,7 +977,7 @@ class RequestHandler {
 
                 await this._handleNonStreamResponse(proxyRequest, messageQueue, req, res);
             } catch (error) {
-                this._handleRequestError(error, res);
+                this._handleRequestError(error, res, "openai", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -1031,7 +1033,7 @@ class RequestHandler {
                 const rotationCountText =
                     this.config.switchOnUses > 0 ? `${usageCount}/${this.config.switchOnUses}` : `${usageCount}`;
                 this.logger.info(
-                    `[Request] OpenAI generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex})`
+                    `[Request] OpenAI generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex}), request ID: ${requestId}`
                 );
                 if (this.authSwitcher.shouldSwitchByUsage()) {
                     this.needsSwitchingAfterRequest = true;
@@ -1046,7 +1048,9 @@ class RequestHandler {
                 model = result.cleanModelName;
                 modelStreamingMode = result.modelStreamingMode || null;
             } catch (error) {
-                this.logger.error(`[Adapter] OpenAI request translation failed: ${error.message}`);
+                this.logger.error(
+                    `❌ [Adapter] OpenAI request translation failed: ${error.message}, request ID: ${requestId}`
+                );
                 return this._sendErrorResponse(res, 400, "Invalid OpenAI request format.");
             }
 
@@ -1139,7 +1143,9 @@ class RequestHandler {
                     }
 
                     if (initialMessage.event_type === "error") {
-                        this._logFinalRequestFailure(initialMessage, "OpenAI real stream");
+                        this._logFinalRequestFailure(initialMessage, "OpenAI real stream", requestId, {
+                            afterRetries: false,
+                        });
 
                         // Send standard HTTP error response
                         this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message);
@@ -1172,7 +1178,7 @@ class RequestHandler {
                         "Content-Type": "text/event-stream",
                     });
                     this.logger.info(`[Request] OpenAI streaming response (Real Mode) started...`);
-                    await this._streamOpenAIResponse(currentQueue, res, model);
+                    await this._streamOpenAIResponse(currentQueue, res, model, requestId);
                 } else {
                     // OpenAI Fake Stream / Non-Stream mode
                     // Set up keep-alive timer for fake stream mode to prevent client timeout
@@ -1201,12 +1207,12 @@ class RequestHandler {
                         const result = await this._executeRequestWithRetries(proxyRequest, messageQueue);
 
                         if (!result.success) {
-                            this._logFinalRequestFailure(result.error, "OpenAI fake/non-stream");
+                            this._logFinalRequestFailure(result.error, "OpenAI fake/non-stream", requestId);
                             // Send standard HTTP error response for both streaming and non-streaming
                             if (connectionMaintainer) clearTimeout(connectionMaintainer);
                             if (isOpenAIStream && res.headersSent) {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
-                                this._handleRequestError(result.error, res, "openai");
+                                this._handleRequestError(result.error, res, "openai", requestId);
                             } else {
                                 this._sendErrorResponse(res, result.error.status || 500, result.error.message);
                             }
@@ -1261,7 +1267,7 @@ class RequestHandler {
 
                                     if (message.event_type === "error") {
                                         this.logger.error(
-                                            `[Request] Error received during OpenAI fake stream: ${message.message}`
+                                            `❌ [Request] Error received during OpenAI fake stream: ${message.message}`
                                         );
                                         this._markTrackedResponseError(res, message.message, 500);
                                         hadStreamError = true;
@@ -1273,7 +1279,7 @@ class RequestHandler {
                                                 );
                                             } catch (writeError) {
                                                 this.logger.debug(
-                                                    `[Request] Failed to write error to OpenAI fake stream: ${writeError.message}`
+                                                    `❌ [Request] Failed to write error to OpenAI fake stream: ${writeError.message}`
                                                 );
                                             }
                                         }
@@ -1308,14 +1314,16 @@ class RequestHandler {
                                         "[Request] Response no longer writable before final fake OpenAI stream chunks."
                                     );
                                 }
-                                this.logger.info("[Request] Fake mode: Complete content sent at once.");
+                                this.logger.info(
+                                    `✅ [Request] Response completed (OpenAI fake stream), request ID: ${requestId}`
+                                );
                             } catch (error) {
                                 // Classify error type and send appropriate response
                                 this._handleFakeStreamError(error, res, "openai");
                             }
                         } else {
                             // Non-stream
-                            await this._sendOpenAINonStreamResponse(activeQueue, res, model);
+                            await this._sendOpenAINonStreamResponse(activeQueue, res, model, requestId);
                         }
                     } finally {
                         if (connectionMaintainer) clearTimeout(connectionMaintainer);
@@ -1325,7 +1333,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleRequestError(error, res);
+                this._handleRequestError(error, res, "openai", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -1439,7 +1447,7 @@ class RequestHandler {
                 const rotationCountText =
                     this.config.switchOnUses > 0 ? `${usageCount}/${this.config.switchOnUses}` : `${usageCount}`;
                 this.logger.info(
-                    `[Request] OpenAI Response generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex})`
+                    `[Request] OpenAI Response generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex}), request ID: ${requestId}`
                 );
                 if (this.authSwitcher.shouldSwitchByUsage()) {
                     this.needsSwitchingAfterRequest = true;
@@ -1454,7 +1462,9 @@ class RequestHandler {
                 model = result.cleanModelName;
                 modelStreamingMode = result.modelStreamingMode || null;
             } catch (error) {
-                this.logger.error(`[Adapter] OpenAI Response request translation failed: ${error.message}`);
+                this.logger.error(
+                    `❌ [Adapter] OpenAI Response request translation failed: ${error.message}, request ID: ${requestId}`
+                );
                 return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.");
             }
 
@@ -1548,7 +1558,9 @@ class RequestHandler {
                     }
 
                     if (initialMessage.event_type === "error") {
-                        this._logFinalRequestFailure(initialMessage, "OpenAI Response API real stream");
+                        this._logFinalRequestFailure(initialMessage, "OpenAI Response API real stream", requestId, {
+                            afterRetries: false,
+                        });
 
                         // Send standard HTTP error response
                         this._sendErrorResponse(res, initialMessage.status || 500, initialMessage.message);
@@ -1582,6 +1594,7 @@ class RequestHandler {
                     });
                     this.logger.info(`[Request] OpenAI Response API streaming response (Real Mode) started...`);
                     await this._streamOpenAIResponseAPIResponse(currentQueue, res, model, {
+                        requestId,
                         responseDefaults,
                     });
                 } else {
@@ -1612,12 +1625,16 @@ class RequestHandler {
                         const result = await this._executeRequestWithRetries(proxyRequest, messageQueue);
 
                         if (!result.success) {
-                            this._logFinalRequestFailure(result.error, "OpenAI Response API fake/non-stream");
+                            this._logFinalRequestFailure(
+                                result.error,
+                                "OpenAI Response API fake/non-stream",
+                                requestId
+                            );
                             // Send standard HTTP error response for both streaming and non-streaming
                             if (connectionMaintainer) clearTimeout(connectionMaintainer);
                             if (isOpenAIStream && res.headersSent) {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
-                                this._handleRequestError(result.error, res, "response_api");
+                                this._handleRequestError(result.error, res, "response_api", requestId);
                             } else {
                                 this._sendErrorResponse(res, result.error.status || 500, result.error.message);
                             }
@@ -1673,7 +1690,7 @@ class RequestHandler {
 
                                     if (message.event_type === "error") {
                                         this.logger.error(
-                                            `[Request] Error received during OpenAI Response API fake stream: ${message.message}`
+                                            `❌ [Request] Error received during OpenAI Response API fake stream: ${message.message}`
                                         );
                                         this._markTrackedResponseError(res, message.message, 500);
                                         hadStreamError = true;
@@ -1692,7 +1709,7 @@ class RequestHandler {
                                                 );
                                             } catch (writeError) {
                                                 this.logger.debug(
-                                                    `[Request] Failed to write error to OpenAI Response API fake stream: ${writeError.message}`
+                                                    `❌ [Request] Failed to write error to OpenAI Response API fake stream: ${writeError.message}`
                                                 );
                                             }
                                         }
@@ -1729,7 +1746,9 @@ class RequestHandler {
                                         "[Request] Response no longer writable before final fake OpenAI Response API stream chunks."
                                     );
                                 }
-                                this.logger.info("[Request] Fake mode: Complete content sent at once.");
+                                this.logger.info(
+                                    `✅ [Request] Response completed (OpenAI Response API fake stream), request ID: ${requestId}`
+                                );
                             } catch (error) {
                                 // Classify error type and send appropriate response
                                 this._handleFakeStreamError(error, res, "response_api");
@@ -1740,7 +1759,8 @@ class RequestHandler {
                                 activeQueue,
                                 res,
                                 model,
-                                responseDefaults
+                                responseDefaults,
+                                requestId
                             );
                         }
                     } finally {
@@ -1751,7 +1771,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleRequestError(error, res, "response_api");
+                this._handleRequestError(error, res, "response_api", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -1820,7 +1840,7 @@ class RequestHandler {
                 const rotationCountText =
                     this.config.switchOnUses > 0 ? `${usageCount}/${this.config.switchOnUses}` : `${usageCount}`;
                 this.logger.info(
-                    `[Request] Claude generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex})`
+                    `[Request] Claude generation request - account rotation count: ${rotationCountText} (Current account: ${this.currentAuthIndex}), request ID: ${requestId}`
                 );
                 if (this.authSwitcher.shouldSwitchByUsage()) {
                     this.needsSwitchingAfterRequest = true;
@@ -1835,7 +1855,9 @@ class RequestHandler {
                 model = result.cleanModelName;
                 modelStreamingMode = result.modelStreamingMode || null;
             } catch (error) {
-                this.logger.error(`[Adapter] Claude request translation failed: ${error.message}`);
+                this.logger.error(
+                    `❌ [Adapter] Claude request translation failed: ${error.message}, request ID: ${requestId}`
+                );
                 return this._sendClaudeErrorResponse(
                     res,
                     400,
@@ -1934,7 +1956,9 @@ class RequestHandler {
                     }
 
                     if (initialMessage.event_type === "error") {
-                        this._logFinalRequestFailure(initialMessage, "Claude real stream");
+                        this._logFinalRequestFailure(initialMessage, "Claude real stream", requestId, {
+                            afterRetries: false,
+                        });
                         this._sendClaudeErrorResponse(
                             res,
                             initialMessage.status || 500,
@@ -1962,7 +1986,7 @@ class RequestHandler {
                         "Content-Type": "text/event-stream",
                     });
                     this.logger.info(`[Request] Claude streaming response (Real Mode) started...`);
-                    await this._streamClaudeResponse(currentQueue, res, model);
+                    await this._streamClaudeResponse(currentQueue, res, model, requestId);
                 } else {
                     // Claude Fake Stream / Non-Stream mode
                     let connectionMaintainer;
@@ -1990,11 +2014,11 @@ class RequestHandler {
                         const result = await this._executeRequestWithRetries(proxyRequest, messageQueue);
 
                         if (!result.success) {
-                            this._logFinalRequestFailure(result.error, "Claude fake/non-stream");
+                            this._logFinalRequestFailure(result.error, "Claude fake/non-stream", requestId);
                             if (connectionMaintainer) clearTimeout(connectionMaintainer);
                             if (isClaudeStream && res.headersSent) {
                                 // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
-                                this._handleClaudeRequestError(result.error, res);
+                                this._handleClaudeRequestError(result.error, res, requestId);
                             } else {
                                 this._sendClaudeErrorResponse(
                                     res,
@@ -2045,7 +2069,7 @@ class RequestHandler {
 
                                     if (message.event_type === "error") {
                                         this.logger.error(
-                                            `[Request] Error received during Claude fake stream: ${message.message}`
+                                            `❌ [Request] Error received during Claude fake stream: ${message.message}`
                                         );
                                         this._markTrackedResponseError(res, message.message, 500);
                                         hadStreamError = true;
@@ -2063,7 +2087,7 @@ class RequestHandler {
                                                 );
                                             } catch (writeError) {
                                                 this.logger.debug(
-                                                    `[Request] Failed to write error to Claude fake stream: ${writeError.message}`
+                                                    `❌ [Request] Failed to write error to Claude fake stream: ${writeError.message}`
                                                 );
                                             }
                                         }
@@ -2097,14 +2121,16 @@ class RequestHandler {
                                         "[Request] Response no longer writable before final fake Claude stream chunk."
                                     );
                                 }
-                                this.logger.info("[Request] Claude fake mode: Complete content sent at once.");
+                                this.logger.info(
+                                    `✅ [Request] Response completed (Claude fake stream), request ID: ${requestId}`
+                                );
                             } catch (error) {
                                 // Classify error type and send appropriate response
                                 this._handleFakeStreamError(error, res, "claude");
                             }
                         } else {
                             // Non-stream
-                            await this._sendClaudeNonStreamResponse(activeQueue, res, model);
+                            await this._sendClaudeNonStreamResponse(activeQueue, res, model, requestId);
                         }
                     } finally {
                         if (connectionMaintainer) clearTimeout(connectionMaintainer);
@@ -2114,7 +2140,7 @@ class RequestHandler {
                 // Handle queue timeout by notifying browser
                 this._handleQueueTimeout(error, requestId);
 
-                this._handleClaudeRequestError(error, res);
+                this._handleClaudeRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (this.needsSwitchingAfterRequest) {
@@ -2136,6 +2162,7 @@ class RequestHandler {
     // Process Claude count tokens request
     async processClaudeCountTokens(req, res) {
         const requestId = this._generateRequestId();
+        this.logger.info(`[Request] Claude count tokens request started, request ID: ${requestId}`);
         this._startTrackedRequest(requestId, req, {
             apiFormat: "claude",
             isStreaming: false,
@@ -2180,7 +2207,9 @@ class RequestHandler {
                 googleBody = result.googleRequest;
                 model = result.cleanModelName;
             } catch (error) {
-                this.logger.error(`[Adapter] Claude request translation failed: ${error.message}`);
+                this.logger.error(
+                    `❌ [Adapter] Claude request translation failed: ${error.message}, request ID: ${requestId}`
+                );
                 return this._sendClaudeErrorResponse(
                     res,
                     400,
@@ -2235,7 +2264,7 @@ class RequestHandler {
 
                 if (response.event_type === "error") {
                     this.logger.error(
-                        `[Request] Received error from browser, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
+                        `❌ [Request] Received error from browser, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
                     );
                     this._sendClaudeErrorResponse(res, response.status || 500, "api_error", response.message);
                     if (!this._isConnectionResetError(response)) {
@@ -2255,7 +2284,7 @@ class RequestHandler {
                             break;
                         }
                         if (message.event_type === "error") {
-                            this.logger.error(`[Request] Error received during count tokens: ${message.message}`);
+                            this.logger.error(`❌ [Request] Error received during count tokens: ${message.message}`);
                             this._markTrackedResponseError(res, message.message, 500);
                             return this._sendClaudeErrorResponse(res, 500, "api_error", message.message);
                         }
@@ -2280,9 +2309,11 @@ class RequestHandler {
                     input_tokens: totalTokens,
                 });
 
-                this.logger.info(`[Request] Claude count tokens completed: ${totalTokens} input tokens`);
+                this.logger.info(
+                    `✅ [Request] Response completed (Claude count_tokens, input tokens: ${totalTokens}), request ID: ${requestId}`
+                );
             } catch (error) {
-                this._handleClaudeRequestError(error, res);
+                this._handleClaudeRequestError(error, res, requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -2296,6 +2327,7 @@ class RequestHandler {
     // Mirrors OpenAI's /v1/responses/input_tokens by returning only the request-side token count.
     async processOpenAIResponseInputTokens(req, res) {
         const requestId = this._generateRequestId();
+        this.logger.info(`[Request] OpenAI Response input_tokens request started, request ID: ${requestId}`);
         this._startTrackedRequest(requestId, req, {
             apiFormat: "response_api",
             isStreaming: false,
@@ -2337,7 +2369,9 @@ class RequestHandler {
                 googleBody = result.googleRequest;
                 model = result.cleanModelName;
             } catch (error) {
-                this.logger.error(`[Adapter] OpenAI Response input_tokens translation failed: ${error.message}`);
+                this.logger.error(
+                    `❌ [Adapter] OpenAI Response input_tokens translation failed: ${error.message}, request ID: ${requestId}`
+                );
                 return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.");
             }
 
@@ -2385,7 +2419,7 @@ class RequestHandler {
 
                 if (response.event_type === "error") {
                     this.logger.error(
-                        `[Request] Received error from browser for input_tokens, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
+                        `❌ [Request] Received error from browser for input_tokens, will trigger switching logic. Status code: ${response.status}, message: ${response.message}`
                     );
 
                     this._sendErrorResponse(res, response.status || 500, response.message);
@@ -2412,7 +2446,9 @@ class RequestHandler {
                             break;
                         }
                         if (message.event_type === "error") {
-                            this.logger.error(`[Request] Error received during input_tokens count: ${message.message}`);
+                            this.logger.error(
+                                `❌ [Request] Error received during input_tokens count: ${message.message}`
+                            );
                             this._markTrackedResponseError(res, message.message, 500);
                             this._sendErrorResponse(res, 500, message.message);
                             return;
@@ -2426,7 +2462,7 @@ class RequestHandler {
                 try {
                     geminiResponse = JSON.parse(fullBody || response.body);
                 } catch (parseError) {
-                    this.logger.error(`[Request] Failed to parse countTokens response: ${parseError.message}`);
+                    this.logger.error(`❌ [Request] Failed to parse countTokens response: ${parseError.message}`);
                     this._sendErrorResponse(res, 500, "Failed to parse backend response");
                     return;
                 }
@@ -2445,9 +2481,11 @@ class RequestHandler {
                     input_tokens: totalTokens,
                 });
 
-                this.logger.info(`[Request] OpenAI Response input_tokens completed: ${totalTokens} input tokens`);
+                this.logger.info(
+                    `✅ [Request] Response completed (OpenAI Response input_tokens, input tokens: ${totalTokens}), request ID: ${requestId}`
+                );
             } catch (error) {
-                this._handleRequestError(error, res);
+                this._handleRequestError(error, res, "openai", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -2459,7 +2497,7 @@ class RequestHandler {
 
     // === Response Handlers ===
 
-    async _streamClaudeResponse(messageQueue, res, model) {
+    async _streamClaudeResponse(messageQueue, res, model, requestId) {
         const streamState = {};
 
         try {
@@ -2468,12 +2506,12 @@ class RequestHandler {
                 const message = await messageQueue.dequeue(this.timeouts.STREAM_CHUNK);
 
                 if (message.type === "STREAM_END") {
-                    this.logger.info("[Request] Claude stream end signal received.");
+                    this.logger.info(`✅ [Request] Response completed (Claude stream), request ID: ${requestId}`);
                     break;
                 }
 
                 if (message.event_type === "error") {
-                    this.logger.error(`[Request] Error received during Claude stream: ${message.message}`);
+                    this.logger.error(`❌ [Request] Error received during Claude stream: ${message.message}`);
                     this._markTrackedResponseError(res, message.message, 500);
                     // Attempt to send error event to client if headers allowed, then close
                     // Check if response is still writable before attempting to write
@@ -2490,7 +2528,7 @@ class RequestHandler {
                             );
                         } catch (writeError) {
                             this.logger.debug(
-                                `[Request] Failed to write error to Claude stream: ${writeError.message}`
+                                `❌ [Request] Failed to write error to Claude stream: ${writeError.message}`
                             );
                         }
                     }
@@ -2537,19 +2575,19 @@ class RequestHandler {
         }
     }
 
-    async _sendClaudeNonStreamResponse(messageQueue, res, model) {
+    async _sendClaudeNonStreamResponse(messageQueue, res, model, requestId) {
         let fullBody = "";
         let receiving = true;
         while (receiving) {
             const message = await messageQueue.dequeue();
             if (message.type === "STREAM_END") {
-                this.logger.info("[Request] Claude received end signal.");
+                this.logger.debug("[Request] Claude received end signal.");
                 receiving = false;
                 break;
             }
 
             if (message.event_type === "error") {
-                this.logger.error(`[Adapter] Error during Claude non-stream conversion: ${message.message}`);
+                this.logger.error(`❌ [Adapter] Error during Claude non-stream conversion: ${message.message}`);
                 this._sendClaudeErrorResponse(res, 500, "api_error", message.message);
                 return;
             }
@@ -2563,8 +2601,9 @@ class RequestHandler {
             const googleResponse = JSON.parse(fullBody);
             const claudeResponse = this.formatConverter.convertGoogleToClaudeNonStream(googleResponse, model);
             res.type("application/json").send(JSON.stringify(claudeResponse));
+            this.logger.info(`✅ [Request] Response completed (Claude non-stream), request ID: ${requestId}`);
         } catch (e) {
-            this.logger.error(`[Adapter] Failed to parse response for Claude: ${e.message}`);
+            this.logger.error(`❌ [Adapter] Failed to parse response for Claude: ${e.message}`);
             this._sendClaudeErrorResponse(res, 500, "api_error", "Failed to parse backend response");
         }
     }
@@ -2586,16 +2625,19 @@ class RequestHandler {
         }
     }
 
-    _handleClaudeRequestError(error, res) {
+    _handleClaudeRequestError(error, res, requestId = null) {
         // Normalize error message to handle non-Error objects and missing/non-string messages
         const errorMsg = String(error?.message ?? error);
+        const requestIdSuffix = requestId ? `, request ID: ${requestId}` : "";
 
         // Check if this is a client disconnect - if so, just log and return
         if (this._isConnectionResetError(error)) {
             const isClientDisconnect = error.reason === "client_disconnect" || !this._isResponseWritable(res);
             if (isClientDisconnect) {
                 this._markTrackedClientAbort(res, errorMsg);
-                this.logger.info(`[Request] Request terminated: Queue closed (${error.reason || "connection_lost"})`);
+                this.logger.info(
+                    `[Request] Request terminated: Queue closed (${error.reason || "connection_lost"})${requestIdSuffix}`
+                );
                 if (!res.writableEnded) {
                     try {
                         res.end();
@@ -2608,7 +2650,9 @@ class RequestHandler {
         }
 
         if (res.headersSent) {
-            this.logger.error(`[Request] Claude request error (headers already sent): ${errorMsg}`);
+            this.logger.error(
+                `❌ [Request] Claude request error (headers already sent): ${errorMsg}${requestIdSuffix}`
+            );
 
             // Try to send error in SSE format if response is still writable
             if (this._isResponseWritable(res)) {
@@ -2644,14 +2688,16 @@ class RequestHandler {
                         );
                         this.logger.info("[Request] Claude error event sent to SSE stream");
                     } catch (writeError) {
-                        this.logger.error(`[Request] Failed to write error to Claude stream: ${writeError.message}`);
+                        this.logger.error(
+                            `❌ [Request] Failed to write error to Claude stream: ${writeError.message}${requestIdSuffix}`
+                        );
                     }
                 }
             }
 
             if (!res.writableEnded) res.end();
         } else {
-            this.logger.error(`[Request] Claude request error: ${errorMsg}`);
+            this.logger.error(`❌ [Request] Claude request error: ${errorMsg}${requestIdSuffix}`);
             let status = 500;
             let errorType = "api_error";
             // Use precise error type checking instead of string matching
@@ -2704,10 +2750,10 @@ class RequestHandler {
                         `[Request] Request #${proxyRequest.request_id} was properly cancelled by user, not counted in failure statistics.`
                     );
                 } else {
-                    this._logFinalRequestFailure(result.error, "Gemini fake stream");
+                    this._logFinalRequestFailure(result.error, "Gemini fake stream", proxyRequest.request_id);
                     // If keep-alives already started the SSE response, send an SSE error event instead of JSON.
                     if (res.headersSent) {
-                        this._handleRequestError(result.error, res, "gemini");
+                        this._handleRequestError(result.error, res, "gemini", proxyRequest.request_id);
                     } else {
                         this._sendErrorResponse(res, result.error.status || 500, result.error.message);
                     }
@@ -2758,10 +2804,12 @@ class RequestHandler {
                     }
 
                     if (message.event_type === "error") {
-                        this.logger.error(`[Request] Error received during Gemini pseudo-stream: ${message.message}`);
+                        this.logger.error(
+                            `❌ [Request] Error received during Gemini pseudo-stream: ${message.message}`
+                        );
                         this._markTrackedResponseError(res, message.message, 500);
                         hadStreamError = true;
-                        this._handleRequestError({ message: message.message }, res, "gemini");
+                        this._handleRequestError({ message: message.message }, res, "gemini", proxyRequest.request_id);
                         break;
                     }
 
@@ -2911,7 +2959,7 @@ class RequestHandler {
                 }
             } catch (e) {
                 this.logger.error(
-                    `[Request] Failed to parse and split Gemini response: ${e.message}. Sending raw data.`
+                    `❌ [Request] Failed to parse and split Gemini response: ${e.message}. Sending raw data.`
                 );
                 if (fullData) {
                     if (!this._isResponseWritable(res)) {
@@ -2939,21 +2987,22 @@ class RequestHandler {
                 }
             })();
             this.logger.info(
-                `✅ [Request] Response ended, reason: ${finishReason}, request ID: ${proxyRequest.request_id}`
+                `✅ [Request] Response completed (Gemini pseudo-stream, reason: ${finishReason}), request ID: ${proxyRequest.request_id}`
             );
         } catch (error) {
-            this._handleRequestError(error, res, "gemini");
+            this._handleRequestError(error, res, "gemini", proxyRequest.request_id);
         } finally {
             clearTimeout(connectionMaintainer);
             if (!res.writableEnded) {
                 res.end();
             }
-            this.logger.info(`[Request] Response processing ended, request ID: ${proxyRequest.request_id}`);
+            this.logger.debug(
+                `[Request] Pseudo-stream response processing ended, request ID: ${proxyRequest.request_id}`
+            );
         }
     }
 
     async _handleRealStreamResponse(proxyRequest, messageQueue, req, res) {
-        this.logger.info(`[Request] Request dispatched to browser for processing...`);
         let currentQueue = messageQueue;
         let currentQueueAuthIndex = this.currentAuthIndex;
         let headerMessage;
@@ -3016,7 +3065,9 @@ class RequestHandler {
                     `[Request] Request #${proxyRequest.request_id} was properly cancelled by user, not counted in failure statistics.`
                 );
             } else {
-                this._logFinalRequestFailure(headerMessage, "Gemini real stream");
+                this._logFinalRequestFailure(headerMessage, "Gemini real stream", proxyRequest.request_id, {
+                    afterRetries: false,
+                });
                 // Avoid switching account if the error is just a connection reset
                 if (!skipFinalFailureSwitch && !this._isConnectionResetError(headerMessage)) {
                     await this.authSwitcher.handleRequestFailureAndSwitch(headerMessage, null);
@@ -3054,12 +3105,12 @@ class RequestHandler {
             while (true) {
                 const dataMessage = await currentQueue.dequeue(this.timeouts.STREAM_CHUNK);
                 if (dataMessage.type === "STREAM_END") {
-                    this.logger.info("[Request] Received stream end signal.");
+                    this.logger.debug("[Request] Gemini real stream end signal received.");
                     break;
                 }
 
                 if (dataMessage.event_type === "error") {
-                    this.logger.error(`[Request] Error received during Gemini real stream: ${dataMessage.message}`);
+                    this.logger.error(`❌ [Request] Error received during Gemini real stream: ${dataMessage.message}`);
                     this._markTrackedResponseError(res, dataMessage.message, 500);
                     // Check if response is still writable before attempting to write
                     if (this._isResponseWritable(res)) {
@@ -3069,7 +3120,7 @@ class RequestHandler {
                             );
                         } catch (writeError) {
                             this.logger.debug(
-                                `[Request] Failed to write error to Gemini real stream: ${writeError.message}`
+                                `❌ [Request] Failed to write error to Gemini real stream: ${writeError.message}`
                             );
                         }
                     }
@@ -3102,7 +3153,7 @@ class RequestHandler {
                         const lastResponse = JSON.parse(jsonString);
                         const finishReason = lastResponse.candidates?.[0]?.finishReason || "UNKNOWN";
                         this.logger.info(
-                            `✅ [Request] Response ended, reason: ${finishReason}, request ID: ${proxyRequest.request_id}`
+                            `✅ [Request] Response completed (Gemini real stream, reason: ${finishReason}), request ID: ${proxyRequest.request_id}`
                         );
                     }
                 }
@@ -3115,14 +3166,14 @@ class RequestHandler {
                 this._handleRealStreamQueueClosedError(error, res, "gemini");
             } else if (error instanceof QueueTimeoutError || error.code === "QUEUE_TIMEOUT") {
                 // Keep behavior consistent with other interfaces: treat missing stream chunks as a timeout error.
-                this._handleRequestError(error, res, "gemini");
+                this._handleRequestError(error, res, "gemini", proxyRequest.request_id);
             } else {
                 // Unexpected error - rethrow to outer handler
                 throw error;
             }
         } finally {
             if (!res.writableEnded) res.end();
-            this.logger.info(
+            this.logger.debug(
                 `[Request] Real stream response connection closed, request ID: ${proxyRequest.request_id}`
             );
         }
@@ -3139,7 +3190,7 @@ class RequestHandler {
                 if (isUserAbortedError(result.error)) {
                     this.logger.info(`[Request] Request #${proxyRequest.request_id} was properly cancelled by user.`);
                 } else {
-                    this._logFinalRequestFailure(result.error, "Gemini non-stream");
+                    this._logFinalRequestFailure(result.error, "Gemini non-stream", proxyRequest.request_id);
                     // Avoid switching account if the error is just a connection reset
                     if (!result.error.skipAccountSwitch && !this._isConnectionResetError(result.error)) {
                         await this.authSwitcher.handleRequestFailureAndSwitch(result.error, null);
@@ -3173,13 +3224,13 @@ class RequestHandler {
             while (receiving) {
                 const message = await activeQueue.dequeue();
                 if (message.type === "STREAM_END") {
-                    this.logger.info("[Request] Received end signal, data reception complete.");
+                    this.logger.debug("[Request] Gemini non-stream end signal received.");
                     receiving = false;
                     break;
                 }
 
                 if (message.event_type === "error") {
-                    this.logger.error(`[Request] Error received during Gemini non-stream: ${message.message}`);
+                    this.logger.error(`❌ [Request] Error received during Gemini non-stream: ${message.message}`);
                     this._markTrackedResponseError(res, message.message, 500);
                     this._sendErrorResponse(res, 500, message.message);
                     return;
@@ -3197,7 +3248,7 @@ class RequestHandler {
                 this._logGeminiNativeResponseDebug(fullResponse, "non-stream");
                 const finishReason = fullResponse.candidates?.[0]?.finishReason || "UNKNOWN";
                 this.logger.info(
-                    `✅ [Request] Response ended, reason: ${finishReason}, request ID: ${proxyRequest.request_id}`
+                    `✅ [Request] Response completed (Gemini non-stream, reason: ${finishReason}), request ID: ${proxyRequest.request_id}`
                 );
             } catch (e) {
                 // Ignore JSON parsing errors for finish reason
@@ -3212,9 +3263,9 @@ class RequestHandler {
 
             res.send(fullBodyBuffer);
 
-            this.logger.info(`[Request] Complete non-stream response sent to client.`);
+            this.logger.debug(`[Request] Complete non-stream response sent to client.`);
         } catch (error) {
-            this._handleRequestError(error, res);
+            this._handleRequestError(error, res, "openai", proxyRequest.request_id);
         }
     }
 
@@ -3351,7 +3402,7 @@ class RequestHandler {
                     } catch (switchError) {
                         lastError = { ...errorPayload, skipAccountSwitch: true };
                         this.logger.error(
-                            `[Request] Account switch failed during immediate-switch retry flow: ${switchError.message}`
+                            `❌ [Request] Account switch failed during immediate-switch retry flow: ${switchError.message}`
                         );
                         break;
                     }
@@ -3382,7 +3433,7 @@ class RequestHandler {
                 // If it's the last attempt, break the loop to return failure
                 if (retryAttempt >= this.maxRetries) {
                     this.logger.error(
-                        `[Request] All ${this.maxRetries} retries failed for request #${proxyRequest.request_id}. Final error: ${errorPayload.message}`
+                        `❌ [Request] All ${this.maxRetries} retries failed for request #${proxyRequest.request_id}. Final error: ${errorPayload.message}`
                     );
                     break;
                 }
@@ -3436,6 +3487,7 @@ class RequestHandler {
         const streamState = {
             responseDefaults: streamOptions.responseDefaults || {},
         };
+        const requestId = streamOptions.requestId;
         // Keep Response API sequence numbers consistent across helpers that might write to the same SSE response.
         if (res.__responseApiSeq == null) res.__responseApiSeq = 0;
         streamState.sequenceNumber = res.__responseApiSeq;
@@ -3445,12 +3497,14 @@ class RequestHandler {
             while (true) {
                 const message = await messageQueue.dequeue(this.timeouts.STREAM_CHUNK);
                 if (message.type === "STREAM_END") {
-                    this.logger.info("[Request] OpenAI Response API stream end signal received.");
+                    this.logger.info(
+                        `✅ [Request] Response completed (OpenAI Response API stream), request ID: ${requestId}`
+                    );
                     break;
                 }
 
                 if (message.event_type === "error") {
-                    this.logger.error(`[Request] Error received during Response API stream: ${message.message}`);
+                    this.logger.error(`❌ [Request] Error received during Response API stream: ${message.message}`);
                     this._markTrackedResponseError(res, message.message, 500);
                     if (this._isResponseWritable(res)) {
                         try {
@@ -3468,7 +3522,7 @@ class RequestHandler {
                             );
                         } catch (writeError) {
                             this.logger.debug(
-                                `[Request] Failed to write error to Response API stream: ${writeError.message}`
+                                `❌ [Request] Failed to write error to Response API stream: ${writeError.message}`
                             );
                         }
                     }
@@ -3514,7 +3568,7 @@ class RequestHandler {
         }
     }
 
-    async _streamOpenAIResponse(messageQueue, res, model) {
+    async _streamOpenAIResponse(messageQueue, res, model, requestId) {
         const streamState = {};
 
         try {
@@ -3522,7 +3576,6 @@ class RequestHandler {
             while (true) {
                 const message = await messageQueue.dequeue(this.timeouts.STREAM_CHUNK);
                 if (message.type === "STREAM_END") {
-                    this.logger.info("[Request] OpenAI stream end signal received.");
                     if (this._isResponseWritable(res)) {
                         try {
                             res.write("data: [DONE]\n\n");
@@ -3532,11 +3585,12 @@ class RequestHandler {
                             );
                         }
                     }
+                    this.logger.info(`✅ [Request] Response completed (OpenAI stream), request ID: ${requestId}`);
                     break;
                 }
 
                 if (message.event_type === "error") {
-                    this.logger.error(`[Request] Error received during OpenAI stream: ${message.message}`);
+                    this.logger.error(`❌ [Request] Error received during OpenAI stream: ${message.message}`);
                     this._markTrackedResponseError(res, message.message, 500);
                     // Attempt to send error event to client if headers allowed, then close
                     // Check if response is still writable before attempting to write
@@ -3547,7 +3601,7 @@ class RequestHandler {
                             );
                         } catch (writeError) {
                             this.logger.debug(
-                                `[Request] Failed to write error to OpenAI stream: ${writeError.message}`
+                                `❌ [Request] Failed to write error to OpenAI stream: ${writeError.message}`
                             );
                         }
                     }
@@ -3591,20 +3645,20 @@ class RequestHandler {
         }
     }
 
-    async _sendOpenAIResponseAPINonStreamResponse(messageQueue, res, model, responseDefaults = {}) {
+    async _sendOpenAIResponseAPINonStreamResponse(messageQueue, res, model, responseDefaults = {}, requestId) {
         let fullBody = "";
         let receiving = true;
         while (receiving) {
             const message = await messageQueue.dequeue();
             if (message.type === "STREAM_END") {
-                this.logger.info("[Request] OpenAI Response API received end signal.");
+                this.logger.debug("[Request] OpenAI Response API received end signal.");
                 receiving = false;
                 break;
             }
 
             if (message.event_type === "error") {
                 this.logger.error(
-                    `[Adapter] Error during OpenAI Response API non-stream conversion: ${message.message}`
+                    `❌ [Adapter] Error during OpenAI Response API non-stream conversion: ${message.message}`
                 );
                 this._sendErrorResponse(res, 500, message.message);
                 return;
@@ -3624,25 +3678,28 @@ class RequestHandler {
                 responseDefaults
             );
             res.type("application/json").send(JSON.stringify(responseAPIResponse));
+            this.logger.info(
+                `✅ [Request] Response completed (OpenAI Response API non-stream), request ID: ${requestId}`
+            );
         } catch (e) {
-            this.logger.error(`[Adapter] Failed to parse response for OpenAI Response API: ${e.message}`);
+            this.logger.error(`❌ [Adapter] Failed to parse response for OpenAI Response API: ${e.message}`);
             this._sendErrorResponse(res, 500, "Failed to parse backend response");
         }
     }
 
-    async _sendOpenAINonStreamResponse(messageQueue, res, model) {
+    async _sendOpenAINonStreamResponse(messageQueue, res, model, requestId) {
         let fullBody = "";
         let receiving = true;
         while (receiving) {
             const message = await messageQueue.dequeue();
             if (message.type === "STREAM_END") {
-                this.logger.info("[Request] OpenAI received end signal.");
+                this.logger.debug("[Request] OpenAI received end signal.");
                 receiving = false;
                 break;
             }
 
             if (message.event_type === "error") {
-                this.logger.error(`[Adapter] Error during OpenAI non-stream conversion: ${message.message}`);
+                this.logger.error(`❌ [Adapter] Error during OpenAI non-stream conversion: ${message.message}`);
                 this._sendErrorResponse(res, 500, message.message);
                 return;
             }
@@ -3657,8 +3714,9 @@ class RequestHandler {
             const googleResponse = JSON.parse(fullBody);
             const openAIResponse = this.formatConverter.convertGoogleToOpenAINonStream(googleResponse, model);
             res.type("application/json").send(JSON.stringify(openAIResponse));
+            this.logger.info(`✅ [Request] Response completed (OpenAI non-stream), request ID: ${requestId}`);
         } catch (e) {
-            this.logger.error(`[Adapter] Failed to parse response for OpenAI: ${e.message}`);
+            this.logger.error(`❌ [Adapter] Failed to parse response for OpenAI: ${e.message}`);
             this._sendErrorResponse(res, 500, "Failed to parse backend response");
         }
     }
@@ -3710,16 +3768,19 @@ class RequestHandler {
         });
     }
 
-    _handleRequestError(error, res, format = "openai") {
+    _handleRequestError(error, res, format = "openai", requestId = null) {
         // Normalize error message to handle non-Error objects and missing/non-string messages
         const errorMsg = String(error?.message ?? error);
+        const requestIdSuffix = requestId ? `, request ID: ${requestId}` : "";
 
         // Check if this is a client disconnect - if so, just log and return
         if (this._isConnectionResetError(error)) {
             const isClientDisconnect = error.reason === "client_disconnect" || !this._isResponseWritable(res);
             if (isClientDisconnect) {
                 this._markTrackedClientAbort(res, errorMsg);
-                this.logger.info(`[Request] Request terminated: Queue closed (${error.reason || "connection_lost"})`);
+                this.logger.info(
+                    `[Request] Request terminated: Queue closed (${error.reason || "connection_lost"})${requestIdSuffix}`
+                );
                 if (!res.writableEnded) {
                     try {
                         res.end();
@@ -3732,7 +3793,9 @@ class RequestHandler {
         }
 
         if (res.headersSent) {
-            this.logger.error(`[Request] Request processing error (headers already sent): ${errorMsg}`);
+            this.logger.error(
+                `❌ [Request] Request processing error (headers already sent): ${errorMsg}${requestIdSuffix}`
+            );
 
             // Try to send error in the stream format
             if (this._isResponseWritable(res)) {
@@ -3808,7 +3871,9 @@ class RequestHandler {
                         this.logger.info("[Request] Error event sent to SSE stream");
                     } catch (writeError) {
                         const writeErrorMsg = String(writeError?.message ?? writeError);
-                        this.logger.error(`[Request] Failed to write error to stream: ${writeErrorMsg}`);
+                        this.logger.error(
+                            `❌ [Request] Failed to write error to stream: ${writeErrorMsg}${requestIdSuffix}`
+                        );
                     }
                 } else if (res.__proxyResponseStreamMode === "fake") {
                     // Request-scoped fake stream mode - try to send an SSE-style error chunk
@@ -3822,7 +3887,9 @@ class RequestHandler {
                         this._sendErrorChunkToClient(res, `Processing failed: ${errorMsg}`, status);
                     } catch (writeError) {
                         const writeErrorMsg = String(writeError?.message ?? writeError);
-                        this.logger.error(`[Request] Failed to write error chunk: ${writeErrorMsg}`);
+                        this.logger.error(
+                            `❌ [Request] Failed to write error chunk: ${writeErrorMsg}${requestIdSuffix}`
+                        );
                     }
                 }
 
@@ -3833,7 +3900,7 @@ class RequestHandler {
                 }
             }
         } else {
-            this.logger.error(`[Request] Request processing error: ${errorMsg}`);
+            this.logger.error(`❌ [Request] Request processing error: ${errorMsg}${requestIdSuffix}`);
             let status = 500;
             // Use precise error type checking instead of string matching
             if (error instanceof QueueTimeoutError || error.code === "QUEUE_TIMEOUT") {
@@ -4166,11 +4233,17 @@ class RequestHandler {
     }
 
     _advanceProxyRequestAttempt(proxyRequest) {
+        const previousAttemptId = proxyRequest.request_attempt_id;
         proxyRequest.request_attempt_number = (proxyRequest.request_attempt_number || 1) + 1;
         proxyRequest.request_attempt_id = this._generateRequestAttemptId(
             proxyRequest.request_id,
             proxyRequest.request_attempt_number
         );
+        if (previousAttemptId && previousAttemptId !== proxyRequest.request_attempt_id) {
+            this.logger.info(
+                `[Request] Retry attempt ID changed for request ID: ${proxyRequest.request_id}, attempt ID: ${proxyRequest.request_attempt_id}`
+            );
+        }
     }
 
     _forwardRequest(proxyRequest) {

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -3319,6 +3319,8 @@ class RequestHandler {
                     !isUserAbortedError(errorPayload)
                 ) {
                     this.logger.warn(`[Request] Received ${errorStatus}, preparing retry...`);
+                    this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                     try {
                         const retryPrepared = await this._prepareImmediateStatusRetry(
                             errorPayload,
@@ -3337,8 +3339,6 @@ class RequestHandler {
                         );
                         break;
                     }
-
-                    this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                     try {
                         currentQueue.close("retry_creating_new_queue");

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -3337,6 +3337,9 @@ class RequestHandler {
                         );
                         break;
                     }
+
+                    this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                     try {
                         currentQueue.close("retry_creating_new_queue");
                     } catch (e) {
@@ -3997,6 +4000,12 @@ class RequestHandler {
     }
 
     _cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex) {
+        if (!Number.isInteger(currentQueueAuthIndex) || currentQueueAuthIndex < 0) {
+            this.logger.debug(
+                `[Request] Skipping retry cancellation for request #${proxyRequest.request_id}: invalid auth index ${currentQueueAuthIndex}.`
+            );
+            return;
+        }
         this._cancelBrowserRequest(proxyRequest.request_id, currentQueueAuthIndex, proxyRequest.request_attempt_id);
     }
 

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -601,7 +601,10 @@ class RequestHandler {
                 sendError: () => {},
             });
             if (!ready) {
-                throw new Error("System not ready after non-current account retry preparation.");
+                throw new Error(
+                    `System not ready after non-current account retry preparation for request #${requestId}: ` +
+                        `status=${errorDetails.status}, sourceAuthIndex=${sourceAuthIndex}, currentAuthIndex=${currentAuthIndex}.`
+                );
             }
 
             const retryAuthIndex = this.currentAuthIndex;
@@ -610,13 +613,15 @@ class RequestHandler {
             }
             if (!Number.isInteger(retryAuthIndex) || retryAuthIndex < 0) {
                 this.logger.warn(
-                    `[Request] Non-current account retry for request #${requestId} did not find a valid current account.`
+                    `[Request] Non-current account retry for request #${requestId} did not find a valid current account ` +
+                        `(status=${errorDetails.status}, sourceAuthIndex=${sourceAuthIndex}, retryAuthIndex=${retryAuthIndex}).`
                 );
                 return false;
             }
             if (tracker.attemptedAuthIndices.has(retryAuthIndex)) {
                 this.logger.warn(
-                    `[Request] Non-current account retry for request #${requestId} would reuse already-attempted account #${retryAuthIndex}, stopping account-switch retries.`
+                    `[Request] Non-current account retry for request #${requestId} would reuse already-attempted account #${retryAuthIndex} ` +
+                        `(status=${errorDetails.status}, sourceAuthIndex=${sourceAuthIndex}), stopping account-switch retries.`
                 );
                 return false;
             }
@@ -1098,15 +1103,15 @@ class RequestHandler {
                             this.config?.immediateSwitchStatusCodes?.includes(initialStatus)
                         ) {
                             this.logger.warn(
-                                `[Request] OpenAI real stream received ${initialStatus}, switching account and retrying...`
+                                `[Request] OpenAI real stream received ${initialStatus}, preparing retry...`
                             );
-                            const switched = await this._prepareImmediateStatusRetry(
+                            const retryPrepared = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
                                 immediateSwitchTracker,
                                 currentQueueAuthIndex
                             );
-                            if (!switched) {
+                            if (!retryPrepared) {
                                 skipFinalFailureSwitch = true;
                                 break;
                             }
@@ -1507,15 +1512,15 @@ class RequestHandler {
                             this.config?.immediateSwitchStatusCodes?.includes(initialStatus)
                         ) {
                             this.logger.warn(
-                                `[Request] OpenAI Response API real stream received ${initialStatus}, switching account and retrying...`
+                                `[Request] OpenAI Response API real stream received ${initialStatus}, preparing retry...`
                             );
-                            const switched = await this._prepareImmediateStatusRetry(
+                            const retryPrepared = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
                                 immediateSwitchTracker,
                                 currentQueueAuthIndex
                             );
-                            if (!switched) {
+                            if (!retryPrepared) {
                                 skipFinalFailureSwitch = true;
                                 break;
                             }
@@ -1893,15 +1898,15 @@ class RequestHandler {
                             this.config?.immediateSwitchStatusCodes?.includes(initialStatus)
                         ) {
                             this.logger.warn(
-                                `[Request] Claude real stream received ${initialStatus}, switching account and retrying...`
+                                `[Request] Claude real stream received ${initialStatus}, preparing retry...`
                             );
-                            const switched = await this._prepareImmediateStatusRetry(
+                            const retryPrepared = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
                                 immediateSwitchTracker,
                                 currentQueueAuthIndex
                             );
-                            if (!switched) {
+                            if (!retryPrepared) {
                                 skipFinalFailureSwitch = true;
                                 break;
                             }
@@ -2970,16 +2975,14 @@ class RequestHandler {
                 Number.isFinite(headerStatus) &&
                 this.config?.immediateSwitchStatusCodes?.includes(headerStatus)
             ) {
-                this.logger.warn(
-                    `[Request] Gemini real stream received ${headerStatus}, switching account and retrying...`
-                );
-                const switched = await this._prepareImmediateStatusRetry(
+                this.logger.warn(`[Request] Gemini real stream received ${headerStatus}, preparing retry...`);
+                const retryPrepared = await this._prepareImmediateStatusRetry(
                     headerMessage,
                     proxyRequest.request_id,
                     immediateSwitchTracker,
                     currentQueueAuthIndex
                 );
-                if (!switched) {
+                if (!retryPrepared) {
                     skipFinalFailureSwitch = true;
                     break;
                 }
@@ -3329,15 +3332,15 @@ class RequestHandler {
                     this.config?.immediateSwitchStatusCodes?.includes(errorStatus) &&
                     !isUserAbortedError(errorPayload)
                 ) {
-                    this.logger.warn(`[Request] Received ${errorStatus}, switching account and retrying...`);
+                    this.logger.warn(`[Request] Received ${errorStatus}, preparing retry...`);
                     try {
-                        const switched = await this._prepareImmediateStatusRetry(
+                        const retryPrepared = await this._prepareImmediateStatusRetry(
                             errorPayload,
                             proxyRequest.request_id,
                             immediateSwitchTracker,
                             currentQueueAuthIndex
                         );
-                        if (!switched) {
+                        if (!retryPrepared) {
                             lastError = { ...errorPayload, skipAccountSwitch: true };
                             break;
                         }

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -3877,11 +3877,14 @@ class RequestHandler {
                     },
                 };
             } else {
+                let statusText = "INTERNAL";
+                if (statusCode === 504) statusText = "DEADLINE_EXCEEDED";
+                else if (statusCode === 503) statusText = "UNAVAILABLE";
                 errorPayload = {
                     error: {
                         code: statusCode,
                         message,
-                        status: "SERVICE_UNAVAILABLE",
+                        status: statusText,
                     },
                 };
             }

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -1138,6 +1138,8 @@ class RequestHandler {
                             this.logger.warn(
                                 `[Request] OpenAI real stream received ${initialStatus}, preparing retry...`
                             );
+                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                             const retryPrepared = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
@@ -1148,8 +1150,6 @@ class RequestHandler {
                                 skipFinalFailureSwitch = true;
                                 break;
                             }
-
-                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                             try {
                                 currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
@@ -1170,6 +1170,7 @@ class RequestHandler {
                     }
 
                     if (initialMessage.event_type === "error") {
+                        this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
                         this._logFinalRequestFailure(initialMessage, "OpenAI real stream", requestId, {
                             afterRetries: false,
                         });
@@ -1564,6 +1565,8 @@ class RequestHandler {
                             this.logger.warn(
                                 `[Request] OpenAI Response API real stream received ${initialStatus}, preparing retry...`
                             );
+                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                             const retryPrepared = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
@@ -1574,8 +1577,6 @@ class RequestHandler {
                                 skipFinalFailureSwitch = true;
                                 break;
                             }
-
-                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                             try {
                                 currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
@@ -1596,6 +1597,7 @@ class RequestHandler {
                     }
 
                     if (initialMessage.event_type === "error") {
+                        this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
                         this._logFinalRequestFailure(initialMessage, "OpenAI Response API real stream", requestId, {
                             afterRetries: false,
                         });
@@ -1959,6 +1961,8 @@ class RequestHandler {
                             this.logger.warn(
                                 `[Request] Claude real stream received ${initialStatus}, preparing retry...`
                             );
+                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                             const retryPrepared = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
@@ -1969,8 +1973,6 @@ class RequestHandler {
                                 skipFinalFailureSwitch = true;
                                 break;
                             }
-
-                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                             try {
                                 currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
@@ -1991,6 +1993,7 @@ class RequestHandler {
                     }
 
                     if (initialMessage.event_type === "error") {
+                        this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
                         this._logFinalRequestFailure(initialMessage, "Claude real stream", requestId, {
                             afterRetries: false,
                         });
@@ -2958,6 +2961,8 @@ class RequestHandler {
                 this.config?.immediateSwitchStatusCodes?.includes(headerStatus)
             ) {
                 this.logger.warn(`[Request] Gemini real stream received ${headerStatus}, preparing retry...`);
+                this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                 const retryPrepared = await this._prepareImmediateStatusRetry(
                     headerMessage,
                     proxyRequest.request_id,
@@ -2968,8 +2973,6 @@ class RequestHandler {
                     skipFinalFailureSwitch = true;
                     break;
                 }
-
-                this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                 try {
                     currentQueue.close(this._getImmediateStatusRetryCloseReason(headerStatus));
@@ -2991,6 +2994,7 @@ class RequestHandler {
         }
 
         if (headerMessage.event_type === "error") {
+            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
             if (isUserAbortedError(headerMessage)) {
                 this.logger.debug(
                     `[Request] Request #${proxyRequest.request_id} was properly cancelled by user, not counted in failure statistics.`
@@ -3310,6 +3314,7 @@ class RequestHandler {
                 }
 
                 lastError = errorPayload;
+                this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                 // Check if we should stop retrying immediately based on status code
                 const errorStatus = Number(errorPayload?.status);
@@ -3319,8 +3324,6 @@ class RequestHandler {
                     !isUserAbortedError(errorPayload)
                 ) {
                     this.logger.warn(`[Request] Received ${errorStatus}, preparing retry...`);
-                    this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
-
                     try {
                         const retryPrepared = await this._prepareImmediateStatusRetry(
                             errorPayload,
@@ -3371,8 +3374,6 @@ class RequestHandler {
                     );
                     break;
                 }
-
-                this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                 // Explicitly close the old queue before creating a new one
                 // This ensures waitingResolvers are properly rejected even if authIndex changed

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -1014,7 +1014,9 @@ class RequestHandler {
 
             // Wait for system to become ready if it's busy
             {
-                const ready = await this._waitForSystemAndConnectionIfBusy(res);
+                const ready = await this._waitForSystemAndConnectionIfBusy(res, {
+                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "openai"),
+                });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
                     return;
@@ -1386,7 +1388,9 @@ class RequestHandler {
 
             // Wait for system to become ready if it's busy
             {
-                const ready = await this._waitForSystemAndConnectionIfBusy(res);
+                const ready = await this._waitForSystemAndConnectionIfBusy(res, {
+                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "response_api"),
+                });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
                     return;
@@ -2376,7 +2380,9 @@ class RequestHandler {
 
             // Wait for system to become ready if it's busy
             {
-                const ready = await this._waitForSystemAndConnectionIfBusy(res);
+                const ready = await this._waitForSystemAndConnectionIfBusy(res, {
+                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "response_api"),
+                });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
                     return;
@@ -2510,7 +2516,7 @@ class RequestHandler {
                     `✅ [Request] Response completed (OpenAI Response input_tokens, input tokens: ${totalTokens}), request ID: ${requestId}`
                 );
             } catch (error) {
-                this._handleRequestError(error, res, "openai", requestId);
+                this._handleRequestError(error, res, "response_api", requestId);
             } finally {
                 this.connectionRegistry.removeMessageQueue(requestId, "request_complete");
                 if (!res.writableEnded) res.end();
@@ -3731,7 +3737,7 @@ class RequestHandler {
                             errorMessage = `Stream timeout: ${errorMsg}`;
                         } else if (this._isConnectionResetError(error)) {
                             errorCode = 503;
-                            errorType = "service_unavailable";
+                            errorType = format === "claude" ? "overloaded_error" : "service_unavailable";
                             errorMessage = `Service unavailable: ${errorMsg}`;
                         }
 
@@ -3824,7 +3830,7 @@ class RequestHandler {
                 errorType = "timeout_error";
             } else if (this._isConnectionResetError(error)) {
                 status = 503;
-                errorType = "service_unavailable";
+                errorType = format === "claude" ? "overloaded_error" : "service_unavailable";
                 this.logger.info(`[Request] Queue closed, returning 503 Service Unavailable.`);
             }
             this._sendErrorResponse(res, status, `Proxy error: ${errorMsg}`, format, errorType);

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -1124,6 +1124,8 @@ class RequestHandler {
                                 break;
                             }
 
+                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                             try {
                                 currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
                             } catch {
@@ -1539,6 +1541,8 @@ class RequestHandler {
                                 break;
                             }
 
+                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                             try {
                                 currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
                             } catch {
@@ -1936,6 +1940,8 @@ class RequestHandler {
                                 skipFinalFailureSwitch = true;
                                 break;
                             }
+
+                            this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                             try {
                                 currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
@@ -3040,6 +3046,8 @@ class RequestHandler {
                     break;
                 }
 
+                this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
+
                 try {
                     currentQueue.close(this._getImmediateStatusRetryCloseReason(headerStatus));
                 } catch {
@@ -3438,14 +3446,7 @@ class RequestHandler {
                     break;
                 }
 
-                // Cancel browser request on the ORIGINAL account that owns this queue.
-                // request_attempt_id isolates retries so a delayed cancel cannot abort a newer attempt.
-                // If account has switched, currentAuthIndex may differ from currentQueueAuthIndex.
-                this._cancelBrowserRequest(
-                    proxyRequest.request_id,
-                    currentQueueAuthIndex,
-                    proxyRequest.request_attempt_id
-                );
+                this._cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex);
 
                 // Explicitly close the old queue before creating a new one
                 // This ensures waitingResolvers are properly rejected even if authIndex changed
@@ -3993,6 +3994,10 @@ class RequestHandler {
                 `[Request] Unable to send cancel instruction: No available WebSocket connection for account #${targetAuthIndex}.`
             );
         }
+    }
+
+    _cancelCurrentAttemptBeforeRetry(proxyRequest, currentQueueAuthIndex) {
+        this._cancelBrowserRequest(proxyRequest.request_id, currentQueueAuthIndex, proxyRequest.request_attempt_id);
     }
 
     /**

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -559,6 +559,10 @@ class RequestHandler {
         return { attemptedAuthIndices };
     }
 
+    _getImmediateStatusRetryCloseReason(status) {
+        return `immediate_status_retry_${status}`;
+    }
+
     async _performImmediateSwitchRetry(errorDetails, requestId, tracker) {
         await this.authSwitcher.handleRequestFailureAndSwitch(
             { message: errorDetails.message, status: Number(errorDetails.status) },
@@ -1117,7 +1121,7 @@ class RequestHandler {
                             }
 
                             try {
-                                currentQueue.close("retry_after_429");
+                                currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
                             } catch {
                                 /* empty */
                             }
@@ -1526,7 +1530,7 @@ class RequestHandler {
                             }
 
                             try {
-                                currentQueue.close("retry_after_429");
+                                currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
                             } catch {
                                 /* empty */
                             }
@@ -1912,7 +1916,7 @@ class RequestHandler {
                             }
 
                             try {
-                                currentQueue.close("retry_after_429");
+                                currentQueue.close(this._getImmediateStatusRetryCloseReason(initialStatus));
                             } catch {
                                 /* empty */
                             }
@@ -2988,7 +2992,7 @@ class RequestHandler {
                 }
 
                 try {
-                    currentQueue.close("retry_after_429");
+                    currentQueue.close(this._getImmediateStatusRetryCloseReason(headerStatus));
                 } catch {
                     /* empty */
                 }

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -4233,17 +4233,11 @@ class RequestHandler {
     }
 
     _advanceProxyRequestAttempt(proxyRequest) {
-        const previousAttemptId = proxyRequest.request_attempt_id;
         proxyRequest.request_attempt_number = (proxyRequest.request_attempt_number || 1) + 1;
         proxyRequest.request_attempt_id = this._generateRequestAttemptId(
             proxyRequest.request_id,
             proxyRequest.request_attempt_number
         );
-        if (previousAttemptId && previousAttemptId !== proxyRequest.request_attempt_id) {
-            this.logger.info(
-                `[Request] Retry attempt ID changed for request ID: ${proxyRequest.request_id}, attempt ID: ${proxyRequest.request_attempt_id}`
-            );
-        }
     }
 
     _forwardRequest(proxyRequest) {

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -1015,7 +1015,8 @@ class RequestHandler {
             // Wait for system to become ready if it's busy
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
-                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "openai"),
+                    sendError: (status, message) =>
+                        this._sendErrorResponse(res, status, message, "openai", "service_unavailable"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -1053,7 +1054,13 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] OpenAI request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(res, 400, "Invalid OpenAI request format.", "openai");
+                return this._sendErrorResponse(
+                    res,
+                    400,
+                    "Invalid OpenAI request format.",
+                    "openai",
+                    "invalid_request_error"
+                );
             }
 
             const effectiveStreamMode = modelStreamingMode || systemStreamMode;
@@ -1389,7 +1396,8 @@ class RequestHandler {
             // Wait for system to become ready if it's busy
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
-                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "response_api"),
+                    sendError: (status, message) =>
+                        this._sendErrorResponse(res, status, message, "response_api", "service_unavailable"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -1476,7 +1484,13 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] OpenAI Response request translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.", "response_api");
+                return this._sendErrorResponse(
+                    res,
+                    400,
+                    "Invalid OpenAI Response request format.",
+                    "response_api",
+                    "invalid_request_error"
+                );
             }
 
             const effectiveStreamMode = modelStreamingMode || systemStreamMode;
@@ -2381,7 +2395,8 @@ class RequestHandler {
             // Wait for system to become ready if it's busy
             {
                 const ready = await this._waitForSystemAndConnectionIfBusy(res, {
-                    sendError: (status, message) => this._sendErrorResponse(res, status, message, "response_api"),
+                    sendError: (status, message) =>
+                        this._sendErrorResponse(res, status, message, "response_api", "service_unavailable"),
                 });
                 if (!ready) {
                     this._markTrackedEarlyExitIfNeeded(res, "Service temporarily unavailable: System not ready.");
@@ -2403,7 +2418,13 @@ class RequestHandler {
                 this.logger.error(
                     `❌ [Adapter] OpenAI Response input_tokens translation failed: ${error.message}, request ID: ${requestId}`
                 );
-                return this._sendErrorResponse(res, 400, "Invalid OpenAI Response request format.", "response_api");
+                return this._sendErrorResponse(
+                    res,
+                    400,
+                    "Invalid OpenAI Response request format.",
+                    "response_api",
+                    "invalid_request_error"
+                );
             }
 
             // Gemini countTokens accepts either:

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -551,10 +551,10 @@ class RequestHandler {
         return true;
     }
 
-    _createImmediateSwitchTracker() {
+    _createImmediateSwitchTracker(initialAuthIndex = this.currentAuthIndex) {
         const attemptedAuthIndices = new Set();
-        if (Number.isInteger(this.currentAuthIndex) && this.currentAuthIndex >= 0) {
-            attemptedAuthIndices.add(this.currentAuthIndex);
+        if (Number.isInteger(initialAuthIndex) && initialAuthIndex >= 0) {
+            attemptedAuthIndices.add(initialAuthIndex);
         }
         return { attemptedAuthIndices };
     }
@@ -589,6 +589,48 @@ class RequestHandler {
 
         tracker.attemptedAuthIndices.add(newAuthIndex);
         return true;
+    }
+
+    async _prepareImmediateStatusRetry(errorDetails, requestId, tracker, sourceAuthIndex) {
+        const currentAuthIndex = this.currentAuthIndex;
+        const hasSourceAuth = Number.isInteger(sourceAuthIndex) && sourceAuthIndex >= 0;
+        const hasCurrentAuth = Number.isInteger(currentAuthIndex) && currentAuthIndex >= 0;
+
+        if (hasSourceAuth && hasCurrentAuth && sourceAuthIndex !== currentAuthIndex) {
+            const ready = await this._waitForSystemAndConnectionIfBusy(null, {
+                sendError: () => {},
+            });
+            if (!ready) {
+                throw new Error("System not ready after non-current account retry preparation.");
+            }
+
+            const retryAuthIndex = this.currentAuthIndex;
+            if (sourceAuthIndex === retryAuthIndex) {
+                return this._performImmediateSwitchRetry(errorDetails, requestId, tracker);
+            }
+            if (!Number.isInteger(retryAuthIndex) || retryAuthIndex < 0) {
+                this.logger.warn(
+                    `[Request] Non-current account retry for request #${requestId} did not find a valid current account.`
+                );
+                return false;
+            }
+            if (tracker.attemptedAuthIndices.has(retryAuthIndex)) {
+                this.logger.warn(
+                    `[Request] Non-current account retry for request #${requestId} would reuse already-attempted account #${retryAuthIndex}, stopping account-switch retries.`
+                );
+                return false;
+            }
+
+            this.logger.warn(
+                `[Request] Received ${errorDetails.status} from non-current account #${sourceAuthIndex}; ` +
+                    `retrying request #${requestId} on current account #${retryAuthIndex} without switching.`
+            );
+
+            tracker.attemptedAuthIndices.add(retryAuthIndex);
+            return true;
+        }
+
+        return this._performImmediateSwitchRetry(errorDetails, requestId, tracker);
     }
 
     _logFinalRequestFailure(errorDetails, contextLabel = "Request") {
@@ -1033,9 +1075,10 @@ class RequestHandler {
 
                 if (useRealStream) {
                     let currentQueue = messageQueue;
+                    let currentQueueAuthIndex = this.currentAuthIndex;
                     let initialMessage;
                     let skipFinalFailureSwitch = false;
-                    const immediateSwitchTracker = this._createImmediateSwitchTracker();
+                    const immediateSwitchTracker = this._createImmediateSwitchTracker(currentQueueAuthIndex);
 
                     // eslint-disable-next-line no-constant-condition
                     while (true) {
@@ -1057,10 +1100,11 @@ class RequestHandler {
                             this.logger.warn(
                                 `[Request] OpenAI real stream received ${initialStatus}, switching account and retrying...`
                             );
-                            const switched = await this._performImmediateSwitchRetry(
+                            const switched = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
-                                immediateSwitchTracker
+                                immediateSwitchTracker,
+                                currentQueueAuthIndex
                             );
                             if (!switched) {
                                 skipFinalFailureSwitch = true;
@@ -1078,6 +1122,7 @@ class RequestHandler {
                                 this.currentAuthIndex,
                                 proxyRequest.request_attempt_id
                             );
+                            currentQueueAuthIndex = this.currentAuthIndex;
                             continue;
                         }
 
@@ -1439,9 +1484,10 @@ class RequestHandler {
 
                 if (useRealStream) {
                     let currentQueue = messageQueue;
+                    let currentQueueAuthIndex = this.currentAuthIndex;
                     let initialMessage;
                     let skipFinalFailureSwitch = false;
-                    const immediateSwitchTracker = this._createImmediateSwitchTracker();
+                    const immediateSwitchTracker = this._createImmediateSwitchTracker(currentQueueAuthIndex);
 
                     // eslint-disable-next-line no-constant-condition
                     while (true) {
@@ -1463,10 +1509,11 @@ class RequestHandler {
                             this.logger.warn(
                                 `[Request] OpenAI Response API real stream received ${initialStatus}, switching account and retrying...`
                             );
-                            const switched = await this._performImmediateSwitchRetry(
+                            const switched = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
-                                immediateSwitchTracker
+                                immediateSwitchTracker,
+                                currentQueueAuthIndex
                             );
                             if (!switched) {
                                 skipFinalFailureSwitch = true;
@@ -1484,6 +1531,7 @@ class RequestHandler {
                                 this.currentAuthIndex,
                                 proxyRequest.request_attempt_id
                             );
+                            currentQueueAuthIndex = this.currentAuthIndex;
                             continue;
                         }
 
@@ -1822,9 +1870,10 @@ class RequestHandler {
 
                 if (useRealStream) {
                     let currentQueue = messageQueue;
+                    let currentQueueAuthIndex = this.currentAuthIndex;
                     let initialMessage;
                     let skipFinalFailureSwitch = false;
-                    const immediateSwitchTracker = this._createImmediateSwitchTracker();
+                    const immediateSwitchTracker = this._createImmediateSwitchTracker(currentQueueAuthIndex);
 
                     // eslint-disable-next-line no-constant-condition
                     while (true) {
@@ -1846,10 +1895,11 @@ class RequestHandler {
                             this.logger.warn(
                                 `[Request] Claude real stream received ${initialStatus}, switching account and retrying...`
                             );
-                            const switched = await this._performImmediateSwitchRetry(
+                            const switched = await this._prepareImmediateStatusRetry(
                                 initialMessage,
                                 requestId,
-                                immediateSwitchTracker
+                                immediateSwitchTracker,
+                                currentQueueAuthIndex
                             );
                             if (!switched) {
                                 skipFinalFailureSwitch = true;
@@ -1867,6 +1917,7 @@ class RequestHandler {
                                 this.currentAuthIndex,
                                 proxyRequest.request_attempt_id
                             );
+                            currentQueueAuthIndex = this.currentAuthIndex;
                             continue;
                         }
 
@@ -2895,9 +2946,10 @@ class RequestHandler {
     async _handleRealStreamResponse(proxyRequest, messageQueue, req, res) {
         this.logger.info(`[Request] Request dispatched to browser for processing...`);
         let currentQueue = messageQueue;
+        let currentQueueAuthIndex = this.currentAuthIndex;
         let headerMessage;
         let skipFinalFailureSwitch = false;
-        const immediateSwitchTracker = this._createImmediateSwitchTracker();
+        const immediateSwitchTracker = this._createImmediateSwitchTracker(currentQueueAuthIndex);
 
         // eslint-disable-next-line no-constant-condition
         while (true) {
@@ -2921,10 +2973,11 @@ class RequestHandler {
                 this.logger.warn(
                     `[Request] Gemini real stream received ${headerStatus}, switching account and retrying...`
                 );
-                const switched = await this._performImmediateSwitchRetry(
+                const switched = await this._prepareImmediateStatusRetry(
                     headerMessage,
                     proxyRequest.request_id,
-                    immediateSwitchTracker
+                    immediateSwitchTracker,
+                    currentQueueAuthIndex
                 );
                 if (!switched) {
                     skipFinalFailureSwitch = true;
@@ -2943,6 +2996,7 @@ class RequestHandler {
                     this.currentAuthIndex,
                     proxyRequest.request_attempt_id
                 );
+                currentQueueAuthIndex = this.currentAuthIndex;
                 continue;
             }
 
@@ -3199,7 +3253,7 @@ class RequestHandler {
         // Track the authIndex for the current queue to ensure proper cleanup
         let currentQueueAuthIndex = this.currentAuthIndex;
         let retryAttempt = 1;
-        const immediateSwitchTracker = this._createImmediateSwitchTracker();
+        const immediateSwitchTracker = this._createImmediateSwitchTracker(currentQueueAuthIndex);
 
         while (retryAttempt <= this.maxRetries) {
             // Record attempt at the start of each retry, before forwarding.
@@ -3277,10 +3331,11 @@ class RequestHandler {
                 ) {
                     this.logger.warn(`[Request] Received ${errorStatus}, switching account and retrying...`);
                     try {
-                        const switched = await this._performImmediateSwitchRetry(
+                        const switched = await this._prepareImmediateStatusRetry(
                             errorPayload,
                             proxyRequest.request_id,
-                            immediateSwitchTracker
+                            immediateSwitchTracker,
+                            currentQueueAuthIndex
                         );
                         if (!switched) {
                             lastError = { ...errorPayload, skipAccountSwitch: true };


### PR DESCRIPTION
非当前账号 429 直接使用当前账号再次请求，不再直接触发：切换当前账号到下一个账号。
统一优化请求报错和日志。

Non current account 429 can directly use the current account to request again without directly triggering: switch the current account to the next account.
Unified optimization of request errors and logs.
