### PR TITLE
fix: stop sanitizing native Gemini tool schemas

### DIFF
--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -286,31 +286,17 @@ class FormatConverter {
         // Helper function to recursively sanitize schema:
         // 1. Remove unsupported fields ($schema, additionalProperties)
         // 2. Convert lowercase type to uppercase (object -> OBJECT, string -> STRING, etc.)
-        const sanitizeSchema = (obj, isPropertiesMap = false) => {
+        const sanitizeSchema = obj => {
             if (!obj || typeof obj !== "object") return obj;
 
             const result = Array.isArray(obj) ? [] : {};
 
             for (const key of Object.keys(obj)) {
-                // Skip fields not supported by Gemini API
-                const unsupportedKeys = [
-                    "$schema",
-                    "additionalProperties",
-                    "ref",
-                    "$ref",
-                    "propertyNames",
-                    "patternProperties",
-                    "unevaluatedProperties",
-                ];
-                if (!isPropertiesMap && unsupportedKeys.includes(key)) {
-                    continue;
-                }
-
                 if (key === "type" && typeof obj[key] === "string") {
                     // Convert lowercase type to uppercase for Gemini
                     result[key] = obj[key].toUpperCase();
                 } else if (typeof obj[key] === "object" && obj[key] !== null) {
-                    result[key] = sanitizeSchema(obj[key], key === "properties");
+                    result[key] = sanitizeSchema(obj[key]);
                 } else {
                     result[key] = obj[key];
                 }

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -286,7 +286,7 @@ class FormatConverter {
         // Helper function to recursively sanitize schema:
         // 1. Remove unsupported fields ($schema, additionalProperties)
         // 2. Convert lowercase type to uppercase (object -> OBJECT, string -> STRING, etc.)
-        const sanitizeSchema = obj => {
+        const sanitizeSchema = (obj, isPropertiesMap = false) => {
             if (!obj || typeof obj !== "object") return obj;
 
             const result = Array.isArray(obj) ? [] : {};
@@ -302,7 +302,7 @@ class FormatConverter {
                     "patternProperties",
                     "unevaluatedProperties",
                 ];
-                if (unsupportedKeys.includes(key)) {
+                if (!isPropertiesMap && unsupportedKeys.includes(key)) {
                     continue;
                 }
 
@@ -310,7 +310,7 @@ class FormatConverter {
                     // Convert lowercase type to uppercase for Gemini
                     result[key] = obj[key].toUpperCase();
                 } else if (typeof obj[key] === "object" && obj[key] !== null) {
-                    result[key] = sanitizeSchema(obj[key]);
+                    result[key] = sanitizeSchema(obj[key], key === "properties");
                 } else {
                     result[key] = obj[key];
                 }

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -4137,9 +4137,9 @@ class RequestHandler {
             if (bodyObj.contents) {
                 this.formatConverter.ensureThoughtSignature(bodyObj);
             }
-            // if (bodyObj.tools) {
-            //     this.formatConverter.sanitizeGeminiTools(bodyObj);
-            // }
+            if (bodyObj.tools) {
+                this.formatConverter.sanitizeGeminiTools(bodyObj);
+            }
         }
 
         // Force web search and URL context for native Google requests

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -4137,9 +4137,9 @@ class RequestHandler {
             if (bodyObj.contents) {
                 this.formatConverter.ensureThoughtSignature(bodyObj);
             }
-            if (bodyObj.tools) {
-                this.formatConverter.sanitizeGeminiTools(bodyObj);
-            }
+            // if (bodyObj.tools) {
+            //     this.formatConverter.sanitizeGeminiTools(bodyObj);
+            // }
         }
 
         // Force web search and URL context for native Google requests


### PR DESCRIPTION
Avoid mutating Google Native tool declarations so client-provided schemas are forwarded unchanged.

避免修改 Google 原生工具声明，以便将客户端提供的模式原封不动地转发。

- fix #154 