### PR TITLE
fix: disable DNS over HTTPS in Firefox settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "express-session": "^1.18.0",
         "jszip": "^3.10.1",
         "mime-types": "^3.0.2",
-        "playwright": "^1.53.1",
+        "playwright": "1.59.1",
         "ws": "^8.17.0"
     },
     "devDependencies": {

--- a/scripts/auth/saveAuth.js
+++ b/scripts/auth/saveAuth.js
@@ -14,6 +14,11 @@ const path = require("path");
 // Load environment variables from .env file
 require("dotenv").config({ path: path.resolve(__dirname, "..", "..", ".env") });
 
+const FIREFOX_DOH_DISABLED_PREFS = {
+    "network.trr.mode": 5,
+    "network.trr.uri": "",
+};
+
 // Initialize language from environment variable passed by setupAuth.js
 const normalizeLanguage = value => {
     const normalized = String(value || "")
@@ -926,6 +931,7 @@ const autoFillRecoveryEmailIfRequired = async (page, recoveryEmail, randomWait) 
 
     const browser = await firefox.launch({
         executablePath: browserExecutablePath,
+        firefoxUserPrefs: FIREFOX_DOH_DISABLED_PREFS,
         headless: runtimeOptions.headless,
         ...(proxyConfig ? { proxy: proxyConfig } : {}),
     });

--- a/src/core/BrowserManager.js
+++ b/src/core/BrowserManager.js
@@ -19,6 +19,10 @@ const {
 } = require("../utils/CustomErrors");
 
 const WS_INIT_TIMEOUT_MS = 120000;
+const FIREFOX_DOH_DISABLED_PREFS = {
+    "network.trr.mode": 5,
+    "network.trr.uri": "",
+};
 
 /**
  * Browser Manager Module
@@ -107,6 +111,7 @@ class BrowserManager {
             "network.dns.disablePrefetch": true, // Disable DNS prefetching
             "network.http.speculative-parallel-limit": 0, // Disable speculative connections
             "network.prefetch-next": false, // Disable link prefetching
+            ...FIREFOX_DOH_DISABLED_PREFS, // Disable DoH/TRR to respect system DNS/hosts
             "permissions.default.geo": 0, // 0 = Always deny geolocation
             "services.sync.enabled": false, // Disable Firefox Sync
             "toolkit.cosmeticAnimations.enabled": false, // Disable UI animations
@@ -1343,6 +1348,7 @@ class BrowserManager {
                 ...extraArgs.env,
             },
             executablePath: this.browserExecutablePath,
+            firefoxUserPrefs: FIREFOX_DOH_DISABLED_PREFS,
             headless: false,
             ...(proxyConfig ? { proxy: proxyConfig } : {}),
         });


### PR DESCRIPTION
## Summary

- pins Playwright to 1.59.1 to avoid the Firefox page error crash seen in Playwright 1.60.0
- disables Firefox/Camoufox DoH/TRR so browser DNS resolution respects system DNS and hosts rules
- applies the DoH/TRR prefs to the main browser, VNC temporary browser, and auth-saving browser flow

## Root cause

Playwright 1.60.0 can crash while serializing Firefox page errors when `pageError.location` is missing. Network environments using hosts/DNS overrides can also be bypassed by Firefox DoH/TRR, making AI Studio page errors more likely.

- Fixes #186
