### PR TITLE
fix: improve Claude message conversion

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,9 @@ const ProxyServerSystem = require("./src/core/ProxyServerSystem");
  * Initialize and start the server
  */
 const initializeServer = async () => {
-    const initialAuthIndex = parseInt(process.env.INITIAL_AUTH_INDEX, 10) || null;
+    const parsedInitialAuthIndex = parseInt(process.env.INITIAL_AUTH_INDEX, 10);
+    const initialAuthIndex =
+        Number.isInteger(parsedInitialAuthIndex) && parsedInitialAuthIndex >= 0 ? parsedInitialAuthIndex : null;
 
     try {
         const serverSystem = new ProxyServerSystem();

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -2117,15 +2117,46 @@ class FormatConverter {
             }
         }
 
-        // Extract system message (Claude uses a separate 'system' field)
+        const appendSystemContent = content => {
+            let text = "";
+            if (typeof content === "string") {
+                text = content;
+            } else if (Array.isArray(content)) {
+                text = content
+                    .map(block => {
+                        if (typeof block === "string") return block;
+                        if (block && block.type === "text") return block.text || "";
+                        return block?.text || "";
+                    })
+                    .filter(Boolean)
+                    .join("\n");
+            } else if (content && typeof content === "object") {
+                text = content.text || "";
+            }
+
+            if (!text) return;
+
+            if (systemInstruction) {
+                systemInstruction.parts[0].text = `${systemInstruction.parts[0].text}\n${text}`;
+            } else {
+                systemInstruction = {
+                    parts: [{ text }],
+                    role: "system",
+                };
+            }
+        };
+
+        // Extract system messages into Gemini systemInstruction.
         if (claudeBody.system) {
-            const systemContent = Array.isArray(claudeBody.system)
-                ? claudeBody.system.map(block => (typeof block === "string" ? block : block.text || "")).join("\n")
-                : claudeBody.system;
-            systemInstruction = {
-                parts: [{ text: systemContent }],
-                role: "system",
-            };
+            appendSystemContent(claudeBody.system);
+        }
+
+        if (Array.isArray(claudeBody.messages)) {
+            for (const message of claudeBody.messages) {
+                if (message.role === "system") {
+                    appendSystemContent(message.content);
+                }
+            }
         }
 
         // Buffer for accumulating consecutive tool result parts
@@ -2179,6 +2210,8 @@ class FormatConverter {
 
         // Convert Claude messages to Google format
         for (const message of claudeBody.messages) {
+            if (message.role === "system") continue;
+
             const googleParts = [];
 
             // Handle tool_result role (Claude's function response)
@@ -2210,12 +2243,11 @@ class FormatConverter {
                     // Process non-tool_result content in the same message
                     const otherContent = message.content.filter(block => block.type !== "tool_result");
                     if (otherContent.length > 0) {
-                        flushToolParts();
                         for (const block of otherContent) {
                             if (block.type === "text") {
-                                googleParts.push({ text: block.text });
+                                pendingToolParts.push({ text: block.text });
                             } else if (block.type === "image") {
-                                googleParts.push({
+                                pendingToolParts.push({
                                     inlineData: {
                                         data: block.source.data,
                                         mimeType: block.source.media_type,

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -2141,6 +2141,42 @@ class FormatConverter {
             }
         };
 
+        const ensureGeminiFunctionResponseObject = value => {
+            if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+                return value;
+            }
+            return { result: value };
+        };
+
+        const normalizeClaudeToolResultContent = content => {
+            if (typeof content === "string") {
+                try {
+                    return ensureGeminiFunctionResponseObject(JSON.parse(content));
+                } catch {
+                    return { result: content };
+                }
+            }
+
+            if (Array.isArray(content)) {
+                const textParts = content
+                    .filter(c => c && c.type === "text")
+                    .map(c => c.text || "")
+                    .join("\n");
+
+                if (textParts.length > 0) {
+                    try {
+                        return ensureGeminiFunctionResponseObject(JSON.parse(textParts));
+                    } catch {
+                        return { result: textParts };
+                    }
+                }
+
+                return { result: content };
+            }
+
+            return ensureGeminiFunctionResponseObject(content || { result: "" });
+        };
+
         // Convert Claude messages to Google format
         for (const message of claudeBody.messages) {
             const googleParts = [];
@@ -2150,28 +2186,7 @@ class FormatConverter {
                 const toolResults = message.content.filter(block => block.type === "tool_result");
                 if (toolResults.length > 0) {
                     for (const toolResult of toolResults) {
-                        let responseContent;
-                        if (typeof toolResult.content === "string") {
-                            try {
-                                responseContent = JSON.parse(toolResult.content);
-                            } catch (e) {
-                                /* eslint-disable-line no-unused-vars */
-                                responseContent = { result: toolResult.content };
-                            }
-                        } else if (Array.isArray(toolResult.content)) {
-                            // Handle array content (text blocks, etc.)
-                            const textParts = toolResult.content
-                                .filter(c => c.type === "text")
-                                .map(c => c.text)
-                                .join("\n");
-                            try {
-                                responseContent = JSON.parse(textParts);
-                            } catch {
-                                responseContent = { result: textParts };
-                            }
-                        } else {
-                            responseContent = toolResult.content || { result: "" };
-                        }
+                        const responseContent = normalizeClaudeToolResultContent(toolResult.content);
 
                         // Resolve function name using the map
                         const toolUseId = toolResult.tool_use_id;

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -2205,7 +2205,7 @@ class FormatConverter {
                 return { result: content };
             }
 
-            return ensureGeminiFunctionResponseObject(content || { result: "" });
+            return ensureGeminiFunctionResponseObject(content ?? { result: "" });
         };
 
         // Convert Claude messages to Google format


### PR DESCRIPTION
## 修改

- 修复 Claude `messages[].role === "system"` 转换到 `systemInstruction`
- 修复 `tool_result.content` 为 JSON 数组时的 Gemini `functionResponse.response` 格式
- 修复 `tool_result` 后跟普通文本时被拆成连续 `user` 的问题
- fix #200

