### PR TITLE
feat: add force code execution capability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -131,6 +131,11 @@ FORCE_THINKING=false
 # Default: false
 FORCE_WEB_SEARCH=false
 
+# Force enable code execution for all requests
+# When enabled, all requests will include code execution capability
+# Default: false
+FORCE_CODE_EXECUTION=false
+
 # Force enable URL context for all requests
 # When enabled, all requests will include URL context capability
 # Default: false

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ services:
 | `SAFETY_SETTINGS_THRESHOLD` | 安全设置的等级。官方说明：[Safety settings](https://ai.google.dev/gemini-api/docs/safety-settings?hl=zh-cn) | `OFF`    |
 | `FORCE_THINKING`            | 强制为所有请求启用思考模式。                                                                                | `false`  |
 | `FORCE_WEB_SEARCH`          | 强制为所有请求启用网络搜索。                                                                                | `false`  |
+| `FORCE_CODE_EXECUTION`      | 强制为所有请求启用代码执行。                                                                                | `false`  |
 | `FORCE_URL_CONTEXT`         | 强制为所有请求启用 URL 上下文。                                                                             | `false`  |
 | `CAMOUFOX_EXECUTABLE_PATH`  | Camoufox 浏览器的可执行文件路径（支持绝对或相对路径）。仅在手动下载浏览器时需配置。                         | 自动检测 |
 
@@ -304,7 +305,7 @@ services:
 >
 > 真假流式也支持通过模型名后缀覆盖，支持追加 `-real` 或 `-fake`。该后缀优先级高于系统的真假流式，但只会在流式请求中生效。例如：`gemini-3-flash-preview-fake`。若和思考后缀同时使用，真假流后缀应放在思考后缀之后，例如：`gemini-3-flash-preview-minimal-fake` 或 `gemini-3-flash-preview(minimal)-real`。
 >
-> 联网搜索也支持通过模型名后缀强制开启，支持在模型名最后追加 `-search`。例如：`gemini-3-flash-preview-search`。若和其他后缀同时使用，`-search` 必须放在最末尾；完整组合顺序仍为“思考 -> 流式 -> 搜索”，例如：`gemini-3-flash-preview-minimal-search`、`gemini-3-flash-preview-real-search` 或 `gemini-3-flash-preview(minimal)-fake-search`。
+> 联网搜索和代码执行也支持通过模型名后缀强制开启：联网搜索追加 `-search`，代码执行追加 `-code`。例如：`gemini-3-flash-preview-search` 或 `gemini-3-flash-preview-code`。若和其他后缀同时使用，内置工具后缀放在最后；完整组合顺序为“思考 -> 流式 -> 内置工具”，例如：`gemini-3-flash-preview-minimal-search`、`gemini-3-flash-preview-real-code` 或 `gemini-3-flash-preview(minimal)-fake-search-code`。
 
 ## 📄 许可证
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -277,6 +277,7 @@ Usage:
 | `SAFETY_SETTINGS_THRESHOLD` | Safety settings level. Official docs: [Safety settings](https://ai.google.dev/gemini-api/docs/safety-settings)                                                                        | `OFF`         |
 | `FORCE_THINKING`            | Force enable thinking mode for all requests.                                                                                                                                          | `false`       |
 | `FORCE_WEB_SEARCH`          | Force enable web search for all requests.                                                                                                                                             | `false`       |
+| `FORCE_CODE_EXECUTION`      | Force enable code execution for all requests.                                                                                                                                         | `false`       |
 | `FORCE_URL_CONTEXT`         | Force enable URL context for all requests.                                                                                                                                            | `false`       |
 | `CAMOUFOX_EXECUTABLE_PATH`  | Path to the Camoufox browser executable (supports both absolute and relative paths). Only required if manually downloaded.                                                            | Auto-detected |
 
@@ -302,7 +303,7 @@ Edit `configs/models.json` to customize available models and their settings.
 >
 > Streaming mode can also be overridden with `-real` or `-fake`. This override has higher priority than the system streaming mode, but it only takes effect for streaming requests. For example: `gemini-3-flash-preview-fake`. When used together with a thinking suffix, the streaming suffix should come after the thinking suffix, for example: `gemini-3-flash-preview-minimal-fake` or `gemini-3-flash-preview(minimal)-real`.
 >
-> Web search can also be forced on by appending `-search` to the end of the model name. For example: `gemini-3-flash-preview-search`. When combined with other suffixes, `-search` must be the final suffix; the full combined order remains `thinking -> streaming -> search`, for example: `gemini-3-flash-preview-minimal-search`, `gemini-3-flash-preview-real-search`, or `gemini-3-flash-preview(minimal)-fake-search`.
+> Web search and code execution can also be forced on with model suffixes: append `-search` for web search and `-code` for code execution. For example: `gemini-3-flash-preview-search` or `gemini-3-flash-preview-code`. When combined with other suffixes, built-in tool suffixes should come last; the full combined order is `thinking -> streaming -> built-in tools`, for example: `gemini-3-flash-preview-minimal-search`, `gemini-3-flash-preview-real-code`, or `gemini-3-flash-preview(minimal)-fake-search-code`.
 
 ## 📄 License
 

--- a/src/auth/CreateAuth.js
+++ b/src/auth/CreateAuth.js
@@ -18,7 +18,6 @@ class CreateAuth {
     constructor(serverSystem) {
         this.serverSystem = serverSystem;
         this.logger = serverSystem.logger;
-        this.config = serverSystem.config;
         this.vncSession = null;
         this.currentLockToken = null; // Token to identify who holds the lock
         this.currentVncAbortController = null; // Controller to abort ongoing setup

--- a/src/core/BrowserManager.js
+++ b/src/core/BrowserManager.js
@@ -119,28 +119,6 @@ class BrowserManager {
             "toolkit.telemetry.enabled": false, // Disable telemetry
             "toolkit.telemetry.unified": false, // Disable unified telemetry
         };
-
-        if (this.config.browserExecutablePath) {
-            this.browserExecutablePath = this.config.browserExecutablePath;
-        } else {
-            const platform = os.platform();
-            if (platform === "linux") {
-                this.browserExecutablePath = path.join(process.cwd(), "camoufox-linux", "camoufox");
-            } else if (platform === "win32") {
-                this.browserExecutablePath = path.join(process.cwd(), "camoufox", "camoufox.exe");
-            } else if (platform === "darwin") {
-                this.browserExecutablePath = path.join(
-                    process.cwd(),
-                    "camoufox-macos",
-                    "Camoufox.app",
-                    "Contents",
-                    "MacOS",
-                    "camoufox"
-                );
-            } else {
-                throw new Error(`Unsupported operating system: ${platform}`);
-            }
-        }
     }
 
     get currentAuthIndex() {
@@ -149,6 +127,25 @@ class BrowserManager {
 
     set currentAuthIndex(value) {
         this._currentAuthIndex = value;
+    }
+
+    _getBrowserExecutablePath() {
+        if (this.config.browserExecutablePath) {
+            return this.config.browserExecutablePath;
+        }
+
+        const platform = os.platform();
+        if (platform === "linux") {
+            return path.join(process.cwd(), "camoufox-linux", "camoufox");
+        }
+        if (platform === "win32") {
+            return path.join(process.cwd(), "camoufox", "camoufox.exe");
+        }
+        if (platform === "darwin") {
+            return path.join(process.cwd(), "camoufox-macos", "Camoufox.app", "Contents", "MacOS", "camoufox");
+        }
+
+        throw new Error(`Unsupported operating system: ${platform}`);
     }
 
     /**
@@ -1296,8 +1293,9 @@ class BrowserManager {
 
     async launchBrowserForVNC(extraArgs = {}) {
         this.logger.info("🚀 [VNC] Launching a new, separate, headful browser instance for VNC session...");
-        if (!fs.existsSync(this.browserExecutablePath)) {
-            throw new Error(`Browser executable not found at path: ${this.browserExecutablePath}`);
+        const browserExecutablePath = this._getBrowserExecutablePath();
+        if (!fs.existsSync(browserExecutablePath)) {
+            throw new Error(`Browser executable not found at path: ${browserExecutablePath}`);
         }
 
         const proxyConfig = parseProxyFromEnv();
@@ -1312,7 +1310,7 @@ class BrowserManager {
                 ...process.env,
                 ...extraArgs.env,
             },
-            executablePath: this.browserExecutablePath,
+            executablePath: browserExecutablePath,
             firefoxUserPrefs: FIREFOX_DOH_DISABLED_PREFS,
             headless: false,
             ...(proxyConfig ? { proxy: proxyConfig } : {}),
@@ -1457,13 +1455,14 @@ class BrowserManager {
 
         const proxyConfig = parseProxyFromEnv();
         this.logger.info("🚀 [Browser] Launching main browser instance...");
-        if (!fs.existsSync(this.browserExecutablePath)) {
+        const browserExecutablePath = this._getBrowserExecutablePath();
+        if (!fs.existsSync(browserExecutablePath)) {
             this._currentAuthIndex = -1;
-            throw new Error(`Browser executable not found at path: ${this.browserExecutablePath}`);
+            throw new Error(`Browser executable not found at path: ${browserExecutablePath}`);
         }
         this.browser = await firefox.launch({
             args: this.launchArgs,
-            executablePath: this.browserExecutablePath,
+            executablePath: browserExecutablePath,
             firefoxUserPrefs: this.firefoxUserPrefs,
             headless: true,
             ...(proxyConfig ? { proxy: proxyConfig } : {}),

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -931,14 +931,15 @@ class FormatConverter {
         const toolChoice = openaiBody.tool_choice || openaiBody.function_call;
         if (toolChoice) {
             const functionCallingConfig = {};
+            const hasFunctionDeclarations = this.hasGeminiFunctionDeclarations(googleRequest);
 
-            if (toolChoice === "auto") {
+            if (toolChoice === "auto" && hasFunctionDeclarations) {
                 functionCallingConfig.mode = "AUTO";
-            } else if (toolChoice === "none") {
+            } else if (toolChoice === "none" && hasFunctionDeclarations) {
                 functionCallingConfig.mode = "NONE";
-            } else if (toolChoice === "required") {
+            } else if (toolChoice === "required" && hasFunctionDeclarations) {
                 functionCallingConfig.mode = "ANY";
-            } else if (typeof toolChoice === "object") {
+            } else if (typeof toolChoice === "object" && hasFunctionDeclarations) {
                 // Handle { type: "function", function: { name: "xxx" } }
                 // or legacy { name: "xxx" }
                 const funcName = toolChoice.function?.name || toolChoice.name;
@@ -2619,13 +2620,22 @@ class FormatConverter {
         // Convert Claude tool_choice to Gemini toolConfig
         if (claudeBody.tool_choice) {
             const functionCallingConfig = {};
-            if (claudeBody.tool_choice.type === "auto") {
+            const hasClaudeFunctionDeclarations = this.hasGeminiFunctionDeclarations(googleRequest);
+            const isBuiltInToolChoice =
+                claudeBody.tool_choice.type === "tool" &&
+                ["code_execution", "web_fetch", "web_search"].includes(claudeBody.tool_choice.name);
+            if (claudeBody.tool_choice.type === "auto" && hasClaudeFunctionDeclarations) {
                 functionCallingConfig.mode = "AUTO";
-            } else if (claudeBody.tool_choice.type === "none") {
+            } else if (claudeBody.tool_choice.type === "none" && hasClaudeFunctionDeclarations) {
                 functionCallingConfig.mode = "NONE";
-            } else if (claudeBody.tool_choice.type === "any") {
+            } else if (claudeBody.tool_choice.type === "any" && hasClaudeFunctionDeclarations) {
                 functionCallingConfig.mode = "ANY";
-            } else if (claudeBody.tool_choice.type === "tool" && claudeBody.tool_choice.name) {
+            } else if (
+                claudeBody.tool_choice.type === "tool" &&
+                claudeBody.tool_choice.name &&
+                !isBuiltInToolChoice &&
+                hasClaudeFunctionDeclarations
+            ) {
                 functionCallingConfig.mode = "ANY";
                 functionCallingConfig.allowedFunctionNames = [claudeBody.tool_choice.name];
             }
@@ -3324,6 +3334,13 @@ class FormatConverter {
         googleRequest.generationConfig = generationConfig;
 
         const toolChoice = responseBody.tool_choice;
+        const responseHostedToolTypes = new Set([
+            "code_interpreter",
+            "computer_use_preview",
+            "file_search",
+            "web_search",
+            "web_search_preview",
+        ]);
 
         // Convert tools
         // `tool_choice: {type:"allowed_tools", tools:[...]}` can provide the effective tool set.
@@ -3415,14 +3432,23 @@ class FormatConverter {
                 }
             };
 
+            const ensureCodeExecutionTool = () => {
+                if (!googleRequest.tools) googleRequest.tools = [];
+                if (!FormatConverter.hasGeminiCodeExecutionTool(googleRequest.tools)) {
+                    googleRequest.tools.push({ codeExecution: {} });
+                }
+            };
+
+            const hasFunctionDeclarations = () => this.hasGeminiFunctionDeclarations(googleRequest);
+
             // tool_choice can be a mode string ("none"|"auto"|"required"),
             // or an object selector (allowed_tools/custom/function/hosted tools).
             if (typeof toolChoice === "string") {
-                if (toolChoice === "auto") {
+                if (toolChoice === "auto" && hasFunctionDeclarations()) {
                     functionCallingConfig.mode = "AUTO";
-                } else if (toolChoice === "none") {
+                } else if (toolChoice === "none" && hasFunctionDeclarations()) {
                     functionCallingConfig.mode = "NONE";
-                } else if (toolChoice === "required") {
+                } else if (toolChoice === "required" && hasFunctionDeclarations()) {
                     functionCallingConfig.mode = "ANY";
                 } else if (toolChoice === "file_search" || toolChoice === "computer_use_preview") {
                     this.logger.debug(
@@ -3436,20 +3462,22 @@ class FormatConverter {
             } else if (typeof toolChoice === "object") {
                 if (toolChoice.type === "allowed_tools") {
                     // Constrain available tools. We already used toolChoice.tools as effectiveTools above.
-                    if (toolChoice.mode === "auto") {
-                        functionCallingConfig.mode = "AUTO";
-                    } else if (toolChoice.mode === "required") {
-                        functionCallingConfig.mode = "ANY";
-                    }
+                    // Gemini functionCallingConfig only applies to function declarations, not hosted/built-in tools.
+                    const allowedToolsHaveHostedTool =
+                        Array.isArray(tools) && tools.some(t => t && responseHostedToolTypes.has(t.type));
+                    if (hasFunctionDeclarations() && !allowedToolsHaveHostedTool) {
+                        if (toolChoice.mode === "auto") {
+                            functionCallingConfig.mode = "AUTO";
+                        } else if (toolChoice.mode === "required") {
+                            functionCallingConfig.mode = "ANY";
+                        }
 
-                    // If the allowed tool set includes functions, restrict to those names.
-                    if (Array.isArray(tools)) {
-                        const names = tools
-                            .filter(
-                                t => t && typeof t === "object" && t.type === "function" && typeof t.name === "string"
-                            )
-                            .map(t => t.name)
-                            .filter(Boolean);
+                        const names = Array.isArray(tools)
+                            ? tools
+                                  .filter(t => t && typeof t === "object" && t.type === "function")
+                                  .map(t => (t.function && typeof t.function === "object" ? t.function.name : t.name))
+                                  .filter(Boolean)
+                            : [];
                         if (names.length > 0) {
                             functionCallingConfig.allowedFunctionNames = names;
                         }
@@ -3469,6 +3497,8 @@ class FormatConverter {
                     }
                 } else if (toolChoice.type === "web_search_preview" || toolChoice.type === "web_search") {
                     ensureGoogleSearchTool();
+                } else if (toolChoice.type === "code_interpreter") {
+                    ensureCodeExecutionTool();
                 } else if (toolChoice.type === "file_search" || toolChoice.type === "computer_use_preview") {
                     this.logger.debug(
                         `[Adapter] tool_choice forces unsupported hosted tool (${toolChoice.type}); ignoring.`

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -171,11 +171,10 @@ class FormatConverter {
     constructor(logger, serverSystem) {
         this.logger = logger;
         this.serverSystem = serverSystem;
-        this.config = serverSystem.config;
     }
 
     getDefaultSafetySettings() {
-        const threshold = this.config.safetySettingsThreshold || "OFF";
+        const threshold = this.serverSystem.config.safetySettingsThreshold || "OFF";
         return [
             { category: "HARM_CATEGORY_HARASSMENT", threshold },
             { category: "HARM_CATEGORY_HATE_SPEECH", threshold },
@@ -872,7 +871,10 @@ class FormatConverter {
         }
 
         // Force thinking mode (only set includeThoughts=true when missing)
-        if (this.config.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
+        if (
+            this.serverSystem.config.forceThinking &&
+            (!thinkingConfig || thinkingConfig.includeThoughts === undefined)
+        ) {
             this.logger.info("[Adapter] ⚠️ Force thinking enabled, setting includeThoughts=true for OpenAI request.");
             thinkingConfig = { ...(thinkingConfig || {}), includeThoughts: true };
         }
@@ -1050,9 +1052,9 @@ class FormatConverter {
      * @private
      */
     _finalizeGoogleRequest(googleRequest, options = {}) {
-        const forceCodeExecution = options.forceCodeExecution || this.config.forceCodeExecution;
-        const forceWebSearch = options.forceWebSearch || this.config.forceWebSearch;
-        const forceUrlContext = options.forceUrlContext || this.config.forceUrlContext;
+        const forceCodeExecution = options.forceCodeExecution || this.serverSystem.config.forceCodeExecution;
+        const forceWebSearch = options.forceWebSearch || this.serverSystem.config.forceWebSearch;
+        const forceUrlContext = options.forceUrlContext || this.serverSystem.config.forceUrlContext;
 
         // Force built-in tools
         if (forceWebSearch || forceUrlContext || forceCodeExecution) {
@@ -2460,7 +2462,10 @@ class FormatConverter {
         }
 
         // Force thinking mode (only set includeThoughts=true when missing)
-        if (this.config.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
+        if (
+            this.serverSystem.config.forceThinking &&
+            (!thinkingConfig || thinkingConfig.includeThoughts === undefined)
+        ) {
             this.logger.info("[Adapter] ⚠️ Force thinking enabled, setting includeThoughts=true for Claude request.");
             thinkingConfig = { ...(thinkingConfig || {}), includeThoughts: true };
         }
@@ -3293,7 +3298,10 @@ class FormatConverter {
         }
 
         // Force thinking mode (only set includeThoughts=true when missing)
-        if (this.config.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
+        if (
+            this.serverSystem.config.forceThinking &&
+            (!thinkingConfig || thinkingConfig.includeThoughts === undefined)
+        ) {
             this.logger.info(
                 "[Adapter] ⚠️ Force thinking enabled, setting includeThoughts=true for OpenAI Response API request."
             );

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -2535,6 +2535,7 @@ class FormatConverter {
         googleRequest.generationConfig = generationConfig;
 
         // Convert Claude tools to Gemini functionDeclarations
+        const builtInToolChoiceNames = new Set();
         if (claudeBody.tools && Array.isArray(claudeBody.tools) && claudeBody.tools.length > 0) {
             let hasCodeExecutionTool = false;
             let hasWebSearchTool = false;
@@ -2549,6 +2550,7 @@ class FormatConverter {
                     tool.name === "web_search"
                 ) {
                     hasWebSearchTool = true;
+                    if (tool.name) builtInToolChoiceNames.add(tool.name);
                     this.logger.info(
                         `[Adapter] Detected web search tool in Claude request (name: ${tool.name}, type: ${tool.type}), mapping to Gemini googleSearch.`
                     );
@@ -2558,6 +2560,7 @@ class FormatConverter {
                 // Handle specialized web fetch tool type, mapped to urlContext (Gemini 2.0 Feature)
                 if (typeof tool.type === "string" && tool.type.startsWith("web_fetch_") && tool.name === "web_fetch") {
                     hasUrlContextTool = true;
+                    if (tool.name) builtInToolChoiceNames.add(tool.name);
                     this.logger.info(
                         `[Adapter] Detected web fetch tool in Claude request (name: ${tool.name}, type: ${tool.type}), mapping to Gemini urlContext.`
                     );
@@ -2571,6 +2574,7 @@ class FormatConverter {
                     tool.name === "code_execution"
                 ) {
                     hasCodeExecutionTool = true;
+                    if (tool.name) builtInToolChoiceNames.add(tool.name);
                     this.logger.info(
                         `[Adapter] Detected code execution tool in Claude request (name: ${tool.name}, type: ${tool.type}), mapping to Gemini codeExecution.`
                     );
@@ -2622,8 +2626,7 @@ class FormatConverter {
             const functionCallingConfig = {};
             const hasClaudeFunctionDeclarations = this.hasGeminiFunctionDeclarations(googleRequest);
             const isBuiltInToolChoice =
-                claudeBody.tool_choice.type === "tool" &&
-                ["code_execution", "web_fetch", "web_search"].includes(claudeBody.tool_choice.name);
+                claudeBody.tool_choice.type === "tool" && builtInToolChoiceNames.has(claudeBody.tool_choice.name);
             if (claudeBody.tool_choice.type === "auto" && hasClaudeFunctionDeclarations) {
                 functionCallingConfig.mode = "AUTO";
             } else if (claudeBody.tool_choice.type === "none" && hasClaudeFunctionDeclarations) {

--- a/src/core/FormatConverter.js
+++ b/src/core/FormatConverter.js
@@ -61,16 +61,52 @@ class FormatConverter {
     }
 
     /**
+     * Parse trailing built-in tool suffixes from model name.
+     * Tool suffixes may be chained at the end of the model name, for example:
+     * `gemini-3-flash-preview-minimal-search-code`.
+     *
+     * @param {string} modelName - Original model name
+     * @returns {{ cleanModelName: string, forceWebSearch: boolean, forceCodeExecution: boolean }}
+     */
+    static parseModelBuiltInToolSuffixes(modelName) {
+        if (!modelName || typeof modelName !== "string") {
+            return {
+                cleanModelName: modelName,
+                forceCodeExecution: false,
+                forceWebSearch: false,
+            };
+        }
+
+        let cleanModelName = modelName;
+        let forceCodeExecution = false;
+        let forceWebSearch = false;
+
+        let match = cleanModelName.match(/^(.+)-(search|code)$/i);
+        while (match) {
+            cleanModelName = match[1];
+            const suffix = match[2].toLowerCase();
+            if (suffix === "code") {
+                forceCodeExecution = true;
+            } else {
+                forceWebSearch = true;
+            }
+            match = cleanModelName.match(/^(.+)-(search|code)$/i);
+        }
+
+        return { cleanModelName, forceCodeExecution, forceWebSearch };
+    }
+
+    /**
      * Parse streaming mode suffix from model name.
      * Only matches a trailing `-real` or `-fake` (case-insensitive).
-     * Callers should strip any trailing `-search` suffix before invoking this helper, so the
-     * combined suffix order remains: thinking -> streaming -> search.
+     * Callers should strip trailing built-in tool suffixes before invoking this helper, so the
+     * combined suffix order remains: thinking -> streaming -> built-in tools.
      *
      * Examples:
      * - gemini-3-flash-preview-minimal-fake -> { cleanModelName: "gemini-3-flash-preview-minimal", streamingMode: "fake" }
      * - gemini-3-flash-preview(minimal)-fake -> { cleanModelName: "gemini-3-flash-preview(minimal)", streamingMode: "fake" }
      * - gemini-3-flash-preview-fake-minimal -> no match (thinking must come before streaming)
-     * - gemini-3-flash-preview(minimal)-fake-search -> no direct match here; callers strip `-search` first
+     * - gemini-3-flash-preview(minimal)-fake-search-code -> no direct match here; callers strip tool suffixes first
      *
      * @param {string} modelName - Original model name
      * @returns {{ cleanModelName: string, streamingMode: ("real"|"fake"|null) }}
@@ -135,10 +171,11 @@ class FormatConverter {
     constructor(logger, serverSystem) {
         this.logger = logger;
         this.serverSystem = serverSystem;
+        this.config = serverSystem.config;
     }
 
     getDefaultSafetySettings() {
-        const threshold = this.serverSystem?.config?.safetySettingsThreshold || "OFF";
+        const threshold = this.config.safetySettingsThreshold || "OFF";
         return [
             { category: "HARM_CATEGORY_HARASSMENT", threshold },
             { category: "HARM_CATEGORY_HATE_SPEECH", threshold },
@@ -230,6 +267,13 @@ class FormatConverter {
         return (
             Array.isArray(tools) &&
             tools.some(tool => FormatConverter.hasGeminiToolKey(tool, ["urlContext", "url_context"]))
+        );
+    }
+
+    static hasGeminiCodeExecutionTool(tools) {
+        return (
+            Array.isArray(tools) &&
+            tools.some(tool => FormatConverter.hasGeminiToolKey(tool, ["codeExecution", "code_execution"]))
         );
     }
 
@@ -499,26 +543,32 @@ class FormatConverter {
         this.logger.debug(`[Adapter] Debug: incoming OpenAI Body = ${JSON.stringify(openaiBody, null, 2)}`);
 
         // Parse model suffixes in reverse stripping order:
-        // 1) web search override: only trailing `-search`
+        // 1) built-in tool overrides: trailing `-search` / `-code`
         // 2) streaming override: trailing `-real` / `-fake` after any thinking suffix
         // 3) thinkingLevel override: trailing `-minimal` / `(minimal)` etc.
-        // Combined user-facing suffix order: thinking -> streaming -> search
+        // Combined user-facing suffix order: thinking -> streaming -> built-in tools
         const rawModel = openaiBody.model || "gemini-2.5-flash-lite";
-        const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
-            FormatConverter.parseModelWebSearchSuffix(rawModel);
+        const {
+            cleanModelName: toolStrippedModel,
+            forceCodeExecution: modelForceCodeExecution,
+            forceWebSearch: modelForceWebSearch,
+        } = FormatConverter.parseModelBuiltInToolSuffixes(rawModel);
         const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
-            FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
+            FormatConverter.parseModelStreamingModeSuffix(toolStrippedModel);
         const { cleanModelName, thinkingLevel: modelThinkingLevel } =
             FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
-        if (modelForceWebSearch) {
+        const modelForceToolFlags = [];
+        if (modelForceWebSearch) modelForceToolFlags.push("forceWebSearch=true");
+        if (modelForceCodeExecution) modelForceToolFlags.push("forceCodeExecution=true");
+        if (modelForceToolFlags.length > 0) {
             this.logger.info(
-                `[Adapter] Detected webSearch suffix in model name: "${rawModel}" -> model="${searchStrippedModel}", forceWebSearch=true`
+                `[Adapter] Detected built-in tool suffixes in model name: "${rawModel}" -> model="${toolStrippedModel}", ${modelForceToolFlags.join(", ")}`
             );
         }
         if (modelStreamingMode) {
             this.logger.info(
-                `[Adapter] Detected streamingMode suffix in model name: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                `[Adapter] Detected streamingMode suffix in model name: "${toolStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
             );
         }
         if (modelThinkingLevel) {
@@ -822,7 +872,7 @@ class FormatConverter {
         }
 
         // Force thinking mode (only set includeThoughts=true when missing)
-        if (this.serverSystem.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
+        if (this.config.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
             this.logger.info("[Adapter] ⚠️ Force thinking enabled, setting includeThoughts=true for OpenAI request.");
             thinkingConfig = { ...(thinkingConfig || {}), includeThoughts: true };
         }
@@ -951,7 +1001,10 @@ class FormatConverter {
             }
         }
 
-        this._finalizeGoogleRequest(googleRequest, { forceWebSearch: modelForceWebSearch });
+        this._finalizeGoogleRequest(googleRequest, {
+            forceCodeExecution: modelForceCodeExecution,
+            forceWebSearch: modelForceWebSearch,
+        });
         this.logger.info("[Adapter] OpenAI to Google translation complete.");
         return { cleanModelName, googleRequest, modelStreamingMode };
     }
@@ -987,19 +1040,22 @@ class FormatConverter {
      * 3. Log final request body
      * @param {object} googleRequest - The Gemini request object to finalize
      * @param {object} [options={}] - Per-request tool injection overrides.
+     * @param {boolean} [options.forceCodeExecution] - When truthy, force-enable `codeExecution` for this request
+     * even if `config.forceCodeExecution` is disabled.
      * @param {boolean} [options.forceWebSearch] - When truthy, force-enable `googleSearch` for this request even
-     * if `serverSystem.forceWebSearch` is disabled. Falsy values fall back to the global setting. Current callers
+     * if `config.forceWebSearch` is disabled. Falsy values fall back to the global setting. Current callers
      * use this for model-name-driven overrides such as the `-search` suffix.
      * @param {boolean} [options.forceUrlContext] - When truthy, force-enable `urlContext` for this request even if
-     * `serverSystem.forceUrlContext` is disabled. Falsy values fall back to the global setting.
+     * `config.forceUrlContext` is disabled. Falsy values fall back to the global setting.
      * @private
      */
     _finalizeGoogleRequest(googleRequest, options = {}) {
-        const forceWebSearch = options.forceWebSearch || this.serverSystem.forceWebSearch;
-        const forceUrlContext = options.forceUrlContext || this.serverSystem.forceUrlContext;
+        const forceCodeExecution = options.forceCodeExecution || this.config.forceCodeExecution;
+        const forceWebSearch = options.forceWebSearch || this.config.forceWebSearch;
+        const forceUrlContext = options.forceUrlContext || this.config.forceUrlContext;
 
-        // Force web search and URL context
-        if (forceWebSearch || forceUrlContext) {
+        // Force built-in tools
+        if (forceWebSearch || forceUrlContext || forceCodeExecution) {
             if (!googleRequest.tools) {
                 googleRequest.tools = [];
             }
@@ -1021,6 +1077,15 @@ class FormatConverter {
                 if (!hasUrlContext) {
                     googleRequest.tools.push({ urlContext: {} });
                     toolsToAdd.push("urlContext");
+                }
+            }
+
+            // Handle Code Execution
+            if (forceCodeExecution) {
+                const hasCodeExecution = FormatConverter.hasGeminiCodeExecutionTool(googleRequest.tools);
+                if (!hasCodeExecution) {
+                    googleRequest.tools.push({ codeExecution: {} });
+                    toolsToAdd.push("codeExecution");
                 }
             }
 
@@ -2070,26 +2135,32 @@ class FormatConverter {
         this.logger.debug(`[Adapter] Debug: incoming Claude Body = ${JSON.stringify(claudeBody, null, 2)}`);
 
         // Parse model suffixes in reverse stripping order:
-        // 1) web search override: only trailing `-search`
+        // 1) built-in tool overrides: trailing `-search` / `-code`
         // 2) streaming override: trailing `-real` / `-fake` after any thinking suffix
         // 3) thinkingLevel override: trailing `-minimal` / `(minimal)` etc.
-        // Combined user-facing suffix order: thinking -> streaming -> search
+        // Combined user-facing suffix order: thinking -> streaming -> built-in tools
         const rawModel = claudeBody.model || "gemini-2.5-flash-lite";
-        const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
-            FormatConverter.parseModelWebSearchSuffix(rawModel);
+        const {
+            cleanModelName: toolStrippedModel,
+            forceCodeExecution: modelForceCodeExecution,
+            forceWebSearch: modelForceWebSearch,
+        } = FormatConverter.parseModelBuiltInToolSuffixes(rawModel);
         const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
-            FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
+            FormatConverter.parseModelStreamingModeSuffix(toolStrippedModel);
         const { cleanModelName, thinkingLevel: modelThinkingLevel } =
             FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
-        if (modelForceWebSearch) {
+        const modelForceToolFlags = [];
+        if (modelForceWebSearch) modelForceToolFlags.push("forceWebSearch=true");
+        if (modelForceCodeExecution) modelForceToolFlags.push("forceCodeExecution=true");
+        if (modelForceToolFlags.length > 0) {
             this.logger.info(
-                `[Adapter] Detected webSearch suffix in model name: "${rawModel}" -> model="${searchStrippedModel}", forceWebSearch=true`
+                `[Adapter] Detected built-in tool suffixes in model name: "${rawModel}" -> model="${toolStrippedModel}", ${modelForceToolFlags.join(", ")}`
             );
         }
         if (modelStreamingMode) {
             this.logger.info(
-                `[Adapter] Detected streamingMode suffix in model name: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                `[Adapter] Detected streamingMode suffix in model name: "${toolStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
             );
         }
         if (modelThinkingLevel) {
@@ -2389,7 +2460,7 @@ class FormatConverter {
         }
 
         // Force thinking mode (only set includeThoughts=true when missing)
-        if (this.serverSystem.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
+        if (this.config.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
             this.logger.info("[Adapter] ⚠️ Force thinking enabled, setting includeThoughts=true for Claude request.");
             thinkingConfig = { ...(thinkingConfig || {}), includeThoughts: true };
         }
@@ -2459,13 +2530,18 @@ class FormatConverter {
 
         // Convert Claude tools to Gemini functionDeclarations
         if (claudeBody.tools && Array.isArray(claudeBody.tools) && claudeBody.tools.length > 0) {
+            let hasCodeExecutionTool = false;
             let hasWebSearchTool = false;
             let hasUrlContextTool = false;
             const functionDeclarations = [];
 
             for (const tool of claudeBody.tools) {
                 // Handle specialized web search tool type (e.g. from Claude's search integration)
-                if (tool.type === "web_search_20250305" && tool.name === "web_search") {
+                if (
+                    typeof tool.type === "string" &&
+                    tool.type.startsWith("web_search_") &&
+                    tool.name === "web_search"
+                ) {
                     hasWebSearchTool = true;
                     this.logger.info(
                         `[Adapter] Detected web search tool in Claude request (name: ${tool.name}, type: ${tool.type}), mapping to Gemini googleSearch.`
@@ -2474,10 +2550,23 @@ class FormatConverter {
                 }
 
                 // Handle specialized web fetch tool type, mapped to urlContext (Gemini 2.0 Feature)
-                if (tool.type === "web_fetch_20250910" && tool.name === "web_fetch") {
+                if (typeof tool.type === "string" && tool.type.startsWith("web_fetch_") && tool.name === "web_fetch") {
                     hasUrlContextTool = true;
                     this.logger.info(
                         `[Adapter] Detected web fetch tool in Claude request (name: ${tool.name}, type: ${tool.type}), mapping to Gemini urlContext.`
+                    );
+                    continue; // Skip adding to functionDeclarations
+                }
+
+                // Handle specialized code execution tool, mapped to Gemini codeExecution.
+                if (
+                    typeof tool.type === "string" &&
+                    tool.type.startsWith("code_execution_") &&
+                    tool.name === "code_execution"
+                ) {
+                    hasCodeExecutionTool = true;
+                    this.logger.info(
+                        `[Adapter] Detected code execution tool in Claude request (name: ${tool.name}, type: ${tool.type}), mapping to Gemini codeExecution.`
                     );
                     continue; // Skip adding to functionDeclarations
                 }
@@ -2512,6 +2601,14 @@ class FormatConverter {
                     googleRequest.tools.push({ urlContext: {} });
                 }
             }
+
+            // If code execution tool was found, ensure codeExecution is added to tools
+            if (hasCodeExecutionTool) {
+                if (!googleRequest.tools) googleRequest.tools = [];
+                if (!FormatConverter.hasGeminiCodeExecutionTool(googleRequest.tools)) {
+                    googleRequest.tools.push({ codeExecution: {} });
+                }
+            }
         }
 
         // Convert Claude tool_choice to Gemini toolConfig
@@ -2542,7 +2639,10 @@ class FormatConverter {
             );
         }
 
-        this._finalizeGoogleRequest(googleRequest, { forceWebSearch: modelForceWebSearch });
+        this._finalizeGoogleRequest(googleRequest, {
+            forceCodeExecution: modelForceCodeExecution,
+            forceWebSearch: modelForceWebSearch,
+        });
         this.logger.info("[Adapter] Claude to Google translation complete.");
         return { cleanModelName, googleRequest, modelStreamingMode };
     }
@@ -2901,26 +3001,32 @@ class FormatConverter {
         );
 
         // Parse model suffixes in reverse stripping order:
-        // 1) web search override: only trailing `-search`
+        // 1) built-in tool overrides: trailing `-search` / `-code`
         // 2) streaming override: trailing `-real` / `-fake` after any thinking suffix
         // 3) thinkingLevel override: trailing `-minimal` / `(minimal)` etc.
-        // Combined user-facing suffix order: thinking -> streaming -> search
+        // Combined user-facing suffix order: thinking -> streaming -> built-in tools
         const rawModel = responseBody.model || "gemini-2.5-flash-lite";
-        const { cleanModelName: searchStrippedModel, forceWebSearch: modelForceWebSearch } =
-            FormatConverter.parseModelWebSearchSuffix(rawModel);
+        const {
+            cleanModelName: toolStrippedModel,
+            forceCodeExecution: modelForceCodeExecution,
+            forceWebSearch: modelForceWebSearch,
+        } = FormatConverter.parseModelBuiltInToolSuffixes(rawModel);
         const { cleanModelName: streamStrippedModel, streamingMode: modelStreamingMode } =
-            FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
+            FormatConverter.parseModelStreamingModeSuffix(toolStrippedModel);
         const { cleanModelName, thinkingLevel: modelThinkingLevel } =
             FormatConverter.parseModelThinkingLevel(streamStrippedModel);
 
-        if (modelForceWebSearch) {
+        const modelForceToolFlags = [];
+        if (modelForceWebSearch) modelForceToolFlags.push("forceWebSearch=true");
+        if (modelForceCodeExecution) modelForceToolFlags.push("forceCodeExecution=true");
+        if (modelForceToolFlags.length > 0) {
             this.logger.info(
-                `[Adapter] Detected webSearch suffix in model name: "${rawModel}" -> model="${searchStrippedModel}", forceWebSearch=true`
+                `[Adapter] Detected built-in tool suffixes in model name: "${rawModel}" -> model="${toolStrippedModel}", ${modelForceToolFlags.join(", ")}`
             );
         }
         if (modelStreamingMode) {
             this.logger.info(
-                `[Adapter] Detected streamingMode suffix in model name: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                `[Adapter] Detected streamingMode suffix in model name: "${toolStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
             );
         }
         if (modelThinkingLevel) {
@@ -3187,7 +3293,7 @@ class FormatConverter {
         }
 
         // Force thinking mode (only set includeThoughts=true when missing)
-        if (this.serverSystem.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
+        if (this.config.forceThinking && (!thinkingConfig || thinkingConfig.includeThoughts === undefined)) {
             this.logger.info(
                 "[Adapter] ⚠️ Force thinking enabled, setting includeThoughts=true for OpenAI Response API request."
             );
@@ -3227,11 +3333,14 @@ class FormatConverter {
         const tools = effectiveTools;
         if (tools && Array.isArray(tools) && tools.length > 0) {
             const functionDeclarations = [];
+            let hasCodeExecution = false;
             let hasWebSearch = false;
 
             for (const tool of tools) {
                 if (tool.type === "web_search_preview" || tool.type === "web_search") {
                     hasWebSearch = true;
+                } else if (tool.type === "code_interpreter") {
+                    hasCodeExecution = true;
                 } else if (tool.type === "file_search") {
                     this.logger.debug("[Adapter] file_search tool detected but not supported by Gemini, skipping...");
                 } else if (tool.type === "computer_use_preview") {
@@ -3272,7 +3381,17 @@ class FormatConverter {
                 }
                 if (!FormatConverter.hasGeminiGoogleSearchTool(googleRequest.tools)) {
                     googleRequest.tools.push({ googleSearch: {} });
-                    this.logger.info("[Adapter] Added googleSearch tool for OpenAI Response API web_search_preview");
+                    this.logger.info("[Adapter] Added googleSearch tool for OpenAI Response API web_search");
+                }
+            }
+
+            if (hasCodeExecution) {
+                if (!googleRequest.tools) {
+                    googleRequest.tools = [];
+                }
+                if (!FormatConverter.hasGeminiCodeExecutionTool(googleRequest.tools)) {
+                    googleRequest.tools.push({ codeExecution: {} });
+                    this.logger.info("[Adapter] Added codeExecution tool for OpenAI Response API code execution");
                 }
             }
         }
@@ -3289,7 +3408,7 @@ class FormatConverter {
             };
 
             // tool_choice can be a mode string ("none"|"auto"|"required"),
-            // or a tool selector (e.g. "web_search_preview") or an object (allowed_tools/custom/etc).
+            // or an object selector (allowed_tools/custom/function/hosted tools).
             if (typeof toolChoice === "string") {
                 if (toolChoice === "auto") {
                     functionCallingConfig.mode = "AUTO";
@@ -3297,8 +3416,6 @@ class FormatConverter {
                     functionCallingConfig.mode = "NONE";
                 } else if (toolChoice === "required") {
                     functionCallingConfig.mode = "ANY";
-                } else if (toolChoice === "web_search_preview" || toolChoice === "web_search") {
-                    ensureGoogleSearchTool();
                 } else if (toolChoice === "file_search" || toolChoice === "computer_use_preview") {
                     this.logger.debug(
                         `[Adapter] tool_choice forces unsupported hosted tool (${toolChoice}); ignoring.`
@@ -3397,7 +3514,10 @@ class FormatConverter {
             }
         }
 
-        this._finalizeGoogleRequest(googleRequest, { forceWebSearch: modelForceWebSearch });
+        this._finalizeGoogleRequest(googleRequest, {
+            forceCodeExecution: modelForceCodeExecution,
+            forceWebSearch: modelForceWebSearch,
+        });
         this.logger.info("[Adapter] OpenAI Response API to Google translation complete.");
         return { cleanModelName, googleRequest, modelStreamingMode };
     }

--- a/src/core/ProxyServerSystem.js
+++ b/src/core/ProxyServerSystem.js
@@ -35,10 +35,6 @@ class ProxyServerSystem extends EventEmitter {
 
         const configLoader = new ConfigLoader(this.logger);
         this.config = configLoader.loadConfiguration();
-        this.streamingMode = this.config.streamingMode;
-        this.forceThinking = this.config.forceThinking;
-        this.forceWebSearch = this.config.forceWebSearch;
-        this.forceUrlContext = this.config.forceUrlContext;
 
         this.authSource = new AuthSource(this.logger);
         this.browserManager = new BrowserManager(this.logger, this.config, this.authSource);

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -1139,7 +1139,7 @@ class RequestHandler {
             apiFormat: "openai",
             isStreaming: req.body.stream === true,
             requestCategory: "generation",
-            streamMode: req.body.stream === true ? this.serverSystem.streamingMode : null,
+            streamMode: req.body.stream === true ? this.config.streamingMode : null,
         });
         this._setResponseApiFormat(res, "openai");
         res.__proxyResponseStreamMode = null;
@@ -1150,7 +1150,7 @@ class RequestHandler {
             }
 
             const isOpenAIStream = req.body.stream === true;
-            const systemStreamMode = this.serverSystem.streamingMode;
+            const systemStreamMode = this.config.streamingMode;
 
             // Handle usage counting
             const usageCount = this.authSwitcher.incrementUsageCount();
@@ -1487,7 +1487,7 @@ class RequestHandler {
             apiFormat: "response_api",
             isStreaming: req.body.stream === true,
             requestCategory: "generation",
-            streamMode: req.body.stream === true ? this.serverSystem.streamingMode : null,
+            streamMode: req.body.stream === true ? this.config.streamingMode : null,
         });
         this._setResponseApiFormat(res, "response_api");
         res.__proxyResponseStreamMode = null;
@@ -1547,7 +1547,7 @@ class RequestHandler {
             const responseDefaults = Object.fromEntries(
                 Object.entries(responseDefaultsRaw).filter(([, v]) => v !== undefined)
             );
-            const systemStreamMode = this.serverSystem.streamingMode;
+            const systemStreamMode = this.config.streamingMode;
 
             // Handle usage counting
             const usageCount = this.authSwitcher.incrementUsageCount();
@@ -1913,7 +1913,7 @@ class RequestHandler {
             apiFormat: "claude",
             isStreaming: req.body.stream === true,
             requestCategory: "generation",
-            streamMode: req.body.stream === true ? this.serverSystem.streamingMode : null,
+            streamMode: req.body.stream === true ? this.config.streamingMode : null,
         });
         this._setResponseApiFormat(res, "claude");
         res.__proxyResponseStreamMode = null;
@@ -1924,7 +1924,7 @@ class RequestHandler {
             }
 
             const isClaudeStream = req.body.stream === true;
-            const systemStreamMode = this.serverSystem.streamingMode;
+            const systemStreamMode = this.config.streamingMode;
 
             // Handle usage counting
             const usageCount = this.authSwitcher.incrementUsageCount();
@@ -3745,9 +3745,8 @@ class RequestHandler {
                     if (req && req.headers && req.headers.host) {
                         newAuthority = req.headers.host;
                     } else {
-                        const host =
-                            this.serverSystem.config.host === "0.0.0.0" ? "127.0.0.1" : this.serverSystem.config.host;
-                        newAuthority = `${host}:${this.serverSystem.config.httpPort}`;
+                        const host = this.config.host === "0.0.0.0" ? "127.0.0.1" : this.config.host;
+                        newAuthority = `${host}:${this.config.httpPort}`;
                     }
 
                     const protocol =
@@ -4154,6 +4153,7 @@ class RequestHandler {
         );
         let modelThinkingLevel = null;
         let modelStreamingMode = null;
+        let modelForceCodeExecution = false;
         let modelForceWebSearch = false;
 
         if (modelPathMatch) {
@@ -4161,25 +4161,32 @@ class RequestHandler {
             const rawModelName = modelPathMatch[2];
             const pathSuffix = modelPathMatch[3];
 
-            const { cleanModelName: searchStrippedModel, forceWebSearch: parsedForceWebSearch } =
-                FormatConverter.parseModelWebSearchSuffix(rawModelName);
+            const {
+                cleanModelName: toolStrippedModel,
+                forceCodeExecution: parsedForceCodeExecution,
+                forceWebSearch: parsedForceWebSearch,
+            } = FormatConverter.parseModelBuiltInToolSuffixes(rawModelName);
             const { cleanModelName: streamStrippedModel, streamingMode: parsedStreamingMode } =
-                FormatConverter.parseModelStreamingModeSuffix(searchStrippedModel);
+                FormatConverter.parseModelStreamingModeSuffix(toolStrippedModel);
             const { cleanModelName, thinkingLevel: parsedThinkingLevel } =
                 FormatConverter.parseModelThinkingLevel(streamStrippedModel);
+            modelForceCodeExecution = parsedForceCodeExecution;
             modelForceWebSearch = parsedForceWebSearch;
             modelStreamingMode = parsedStreamingMode;
             modelThinkingLevel = parsedThinkingLevel;
 
-            if (modelForceWebSearch) {
+            const modelForceToolFlags = [];
+            if (modelForceWebSearch) modelForceToolFlags.push("forceWebSearch=true");
+            if (modelForceCodeExecution) modelForceToolFlags.push("forceCodeExecution=true");
+            if (modelForceToolFlags.length > 0) {
                 this.logger.info(
-                    `[Proxy] Detected webSearch suffix in model path: "${rawModelName}" -> model="${searchStrippedModel}", forceWebSearch=true`
+                    `[Proxy] Detected built-in tool suffixes in model path: "${rawModelName}" -> model="${toolStrippedModel}", ${modelForceToolFlags.join(", ")}`
                 );
             }
 
             if (modelStreamingMode) {
                 this.logger.info(
-                    `[Proxy] Detected streamingMode suffix in model path: "${searchStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
+                    `[Proxy] Detected streamingMode suffix in model path: "${toolStrippedModel}" -> model="${streamStrippedModel}", streamingMode="${modelStreamingMode}"`
                 );
             }
 
@@ -4196,7 +4203,7 @@ class RequestHandler {
         }
 
         // Force thinking for native Google requests (processed first)
-        if (this.serverSystem.forceThinking && req.method === "POST" && bodyObj && bodyObj.contents) {
+        if (this.config.forceThinking && req.method === "POST" && bodyObj && bodyObj.contents) {
             if (!bodyObj.generationConfig) {
                 bodyObj.generationConfig = {};
             }
@@ -4248,9 +4255,13 @@ class RequestHandler {
             this.logger.info(`[Proxy] Rewriting embedContent to batchEmbedContents for model "${modelName}".`);
         }
 
-        // Force web search and URL context for native Google requests
+        // Force built-in tools for native Google requests
         if (
-            (this.serverSystem.forceWebSearch || modelForceWebSearch || this.serverSystem.forceUrlContext) &&
+            (this.config.forceWebSearch ||
+                modelForceWebSearch ||
+                this.config.forceUrlContext ||
+                this.config.forceCodeExecution ||
+                modelForceCodeExecution) &&
             req.method === "POST" &&
             bodyObj &&
             bodyObj.contents
@@ -4262,7 +4273,7 @@ class RequestHandler {
             const toolsToAdd = [];
 
             // Handle Google Search
-            if (this.serverSystem.forceWebSearch || modelForceWebSearch) {
+            if (this.config.forceWebSearch || modelForceWebSearch) {
                 const hasSearch = FormatConverter.hasGeminiGoogleSearchTool(bodyObj.tools);
                 if (!hasSearch) {
                     bodyObj.tools.push({ googleSearch: {} });
@@ -4275,7 +4286,7 @@ class RequestHandler {
             }
 
             // Handle URL Context
-            if (this.serverSystem.forceUrlContext) {
+            if (this.config.forceUrlContext) {
                 const hasUrlContext = FormatConverter.hasGeminiUrlContextTool(bodyObj.tools);
                 if (!hasUrlContext) {
                     bodyObj.tools.push({ urlContext: {} });
@@ -4283,6 +4294,19 @@ class RequestHandler {
                 } else {
                     this.logger.info(
                         `[Proxy] ✅ Client-provided URL context detected, skipping force injection. (Google Native)`
+                    );
+                }
+            }
+
+            // Handle Code Execution
+            if (this.config.forceCodeExecution || modelForceCodeExecution) {
+                const hasCodeExecution = FormatConverter.hasGeminiCodeExecutionTool(bodyObj.tools);
+                if (!hasCodeExecution) {
+                    bodyObj.tools.push({ codeExecution: {} });
+                    toolsToAdd.push("codeExecution");
+                } else {
+                    this.logger.info(
+                        `[Proxy] ✅ Client-provided code execution detected, skipping force injection. (Google Native)`
                     );
                 }
             }
@@ -4316,7 +4340,7 @@ class RequestHandler {
             query_params: req.query || {},
             request_id: requestId,
             response_transform: responseTransform,
-            streaming_mode: modelStreamingMode || this.serverSystem.streamingMode,
+            streaming_mode: modelStreamingMode || this.config.streamingMode,
         };
     }
 

--- a/src/core/RequestHandler.js
+++ b/src/core/RequestHandler.js
@@ -36,8 +36,6 @@ class RequestHandler {
         this.authSwitcher = new AuthSwitcher(logger, config, authSource, browserManager);
         this.formatConverter = new FormatConverter(logger, serverSystem);
 
-        this.maxRetries = this.config.maxRetries;
-        this.retryDelay = this.config.retryDelay;
         this.needsSwitchingAfterRequest = false;
 
         // Timeout settings
@@ -3244,7 +3242,7 @@ class RequestHandler {
         let retryAttempt = 1;
         const immediateSwitchTracker = this._createImmediateSwitchTracker(currentQueueAuthIndex);
 
-        while (retryAttempt <= this.maxRetries) {
+        while (retryAttempt <= this.config.maxRetries) {
             // Record attempt at the start of each retry, before forwarding.
             // This ensures failed attempts (e.g. 429 before any response) are also counted.
             this._getUsageStatsService()?.recordAttempt(
@@ -3298,7 +3296,7 @@ class RequestHandler {
                     const canRetryOnCurrentAccountCandidate =
                         !isClientDisconnect &&
                         isClosedAccountRetryable &&
-                        retryAttempt < this.maxRetries &&
+                        retryAttempt < this.config.maxRetries &&
                         Number.isInteger(currentQueueAuthIndex) &&
                         currentQueueAuthIndex >= 0 &&
                         Number.isInteger(currentAuthIndex) &&
@@ -3345,7 +3343,7 @@ class RequestHandler {
                         if (Number.isInteger(currentQueueAuthIndex) && currentQueueAuthIndex >= 0) {
                             immediateSwitchTracker.attemptedAuthIndices.add(currentQueueAuthIndex);
                         }
-                        await new Promise(resolve => setTimeout(resolve, this.retryDelay));
+                        await new Promise(resolve => setTimeout(resolve, this.config.retryDelay));
                         retryAttempt++;
                         continue;
                     } else {
@@ -3422,13 +3420,13 @@ class RequestHandler {
 
                 // Log the warning for the current attempt
                 this.logger.warn(
-                    `[Request] Attempt #${retryAttempt}/${this.maxRetries} for request #${proxyRequest.request_id} failed: ${errorPayload.message}`
+                    `[Request] Attempt #${retryAttempt}/${this.config.maxRetries} for request #${proxyRequest.request_id} failed: ${errorPayload.message}`
                 );
 
                 // If it's the last attempt, break the loop to return failure
-                if (retryAttempt >= this.maxRetries) {
+                if (retryAttempt >= this.config.maxRetries) {
                     this.logger.error(
-                        `❌ [Request] All ${this.maxRetries} retries failed for request #${proxyRequest.request_id}. Final error: ${errorPayload.message}`
+                        `❌ [Request] All ${this.config.maxRetries} retries failed for request #${proxyRequest.request_id}. Final error: ${errorPayload.message}`
                     );
                     break;
                 }
@@ -3460,7 +3458,7 @@ class RequestHandler {
                 }
 
                 // Wait before the next retry
-                await new Promise(resolve => setTimeout(resolve, this.retryDelay));
+                await new Promise(resolve => setTimeout(resolve, this.config.retryDelay));
                 if (
                     !(await this._waitForSystemAndConnectionIfBusy(null, {
                         connectionMessage: "Service temporarily unavailable: Connection not ready before retry.",

--- a/src/routes/AuthRoutes.js
+++ b/src/routes/AuthRoutes.js
@@ -15,7 +15,6 @@ class AuthRoutes {
     constructor(serverSystem) {
         this.serverSystem = serverSystem;
         this.logger = serverSystem.logger;
-        this.config = serverSystem.config;
         this.distIndexPath = serverSystem.distIndexPath;
         this.loginAttempts = new Map(); // Track login attempts for rate limiting
 
@@ -177,7 +176,7 @@ class AuthRoutes {
                     authSuccess = true;
                 }
             } else {
-                if (submittedPassword && this.config.apiKeys.includes(submittedPassword)) {
+                if (submittedPassword && this.serverSystem.config.apiKeys.includes(submittedPassword)) {
                     authSuccess = true;
                 }
             }

--- a/src/routes/StatusRoutes.js
+++ b/src/routes/StatusRoutes.js
@@ -702,9 +702,9 @@ class StatusRoutes {
         app.put("/api/settings/streaming-mode", isAuthenticated, (req, res) => {
             const newMode = req.body.mode;
             if (newMode === "fake" || newMode === "real") {
-                this.serverSystem.streamingMode = newMode;
+                this.config.streamingMode = newMode;
                 this.logger.info(
-                    `[WebUI] Streaming mode switched by authenticated user to: ${this.serverSystem.streamingMode}`
+                    `[WebUI] Streaming mode switched by authenticated user to: ${this.config.streamingMode}`
                 );
                 res.status(200).json({ message: "settingUpdateSuccess", setting: "streamingMode", value: newMode });
             } else {
@@ -713,22 +713,33 @@ class StatusRoutes {
         });
 
         app.put("/api/settings/force-thinking", isAuthenticated, (req, res) => {
-            this.serverSystem.forceThinking = !this.serverSystem.forceThinking;
-            const statusText = this.serverSystem.forceThinking;
+            this.config.forceThinking = !this.config.forceThinking;
+            const statusText = this.config.forceThinking;
             this.logger.info(`[WebUI] Force thinking toggle switched to: ${statusText}`);
             res.status(200).json({ message: "settingUpdateSuccess", setting: "forceThinking", value: statusText });
         });
 
         app.put("/api/settings/force-web-search", isAuthenticated, (req, res) => {
-            this.serverSystem.forceWebSearch = !this.serverSystem.forceWebSearch;
-            const statusText = this.serverSystem.forceWebSearch;
+            this.config.forceWebSearch = !this.config.forceWebSearch;
+            const statusText = this.config.forceWebSearch;
             this.logger.info(`[WebUI] Force web search toggle switched to: ${statusText}`);
             res.status(200).json({ message: "settingUpdateSuccess", setting: "forceWebSearch", value: statusText });
         });
 
+        app.put("/api/settings/force-code-execution", isAuthenticated, (req, res) => {
+            this.config.forceCodeExecution = !this.config.forceCodeExecution;
+            const statusText = this.config.forceCodeExecution;
+            this.logger.info(`[WebUI] Force code execution toggle switched to: ${statusText}`);
+            res.status(200).json({
+                message: "settingUpdateSuccess",
+                setting: "forceCodeExecution",
+                value: statusText,
+            });
+        });
+
         app.put("/api/settings/force-url-context", isAuthenticated, (req, res) => {
-            this.serverSystem.forceUrlContext = !this.serverSystem.forceUrlContext;
-            const statusText = this.serverSystem.forceUrlContext;
+            this.config.forceUrlContext = !this.config.forceUrlContext;
+            const statusText = this.config.forceUrlContext;
             this.logger.info(`[WebUI] Force URL context toggle switched to: ${statusText}`);
             res.status(200).json({ message: "settingUpdateSuccess", setting: "forceUrlContext", value: statusText });
         });
@@ -1004,9 +1015,10 @@ class StatusRoutes {
                 enableAuthUpdate: config.enableAuthUpdate,
                 expiredIndicesRaw: expiredIndices,
                 failureCount,
-                forceThinking: this.serverSystem.forceThinking,
-                forceUrlContext: this.serverSystem.forceUrlContext,
-                forceWebSearch: this.serverSystem.forceWebSearch,
+                forceCodeExecution: config.forceCodeExecution,
+                forceThinking: config.forceThinking,
+                forceUrlContext: config.forceUrlContext,
+                forceWebSearch: config.forceWebSearch,
                 immediateSwitchStatusCodes:
                     config.immediateSwitchStatusCodes.length > 0
                         ? `[${config.immediateSwitchStatusCodes.join(", ")}]`
@@ -1019,7 +1031,7 @@ class StatusRoutes {
                 maxRetries: config.maxRetries,
                 rotationIndicesRaw: rotationIndices,
                 safetySettingsThreshold: config.safetySettingsThreshold,
-                streamingMode: this.serverSystem.streamingMode,
+                streamingMode: config.streamingMode,
                 usageCount,
             },
         };

--- a/src/routes/WebRoutes.js
+++ b/src/routes/WebRoutes.js
@@ -20,7 +20,6 @@ class WebRoutes {
     constructor(serverSystem) {
         this.serverSystem = serverSystem;
         this.logger = serverSystem.logger;
-        this.config = serverSystem.config;
         this.distIndexPath = path.join(__dirname, "..", "..", "ui", "dist", "index.html");
 
         // Pass distIndexPath to serverSystem for other modules to access

--- a/src/utils/ConfigLoader.js
+++ b/src/utils/ConfigLoader.js
@@ -28,6 +28,7 @@ class ConfigLoader {
             enableUsageStats: true,
             failureThreshold: 3,
             fakeStreamTimeoutMs: 300000,
+            forceCodeExecution: false,
             forceThinking: false,
             forceUrlContext: false,
             forceWebSearch: false,
@@ -97,6 +98,8 @@ class ConfigLoader {
         }
         if (process.env.CHECK_UPDATE) config.checkUpdate = process.env.CHECK_UPDATE.toLowerCase() !== "false";
         if (process.env.FORCE_THINKING) config.forceThinking = process.env.FORCE_THINKING.toLowerCase() === "true";
+        if (process.env.FORCE_CODE_EXECUTION)
+            config.forceCodeExecution = process.env.FORCE_CODE_EXECUTION.toLowerCase() === "true";
         if (process.env.FORCE_WEB_SEARCH) config.forceWebSearch = process.env.FORCE_WEB_SEARCH.toLowerCase() === "true";
         if (process.env.FORCE_URL_CONTEXT)
             config.forceUrlContext = process.env.FORCE_URL_CONTEXT.toLowerCase() === "true";
@@ -198,6 +201,7 @@ class ConfigLoader {
         this.logger.info(`  Stream Timeout: ${config.streamTimeoutMs}ms`);
         this.logger.info(`  Fake/Non-Stream Timeout: ${config.fakeStreamTimeoutMs}ms`);
         this.logger.info(`  Force Thinking: ${config.forceThinking}`);
+        this.logger.info(`  Force Code Execution: ${config.forceCodeExecution}`);
         this.logger.info(`  Force Web Search: ${config.forceWebSearch}`);
         this.logger.info(`  Force URL Context: ${config.forceUrlContext}`);
         this.logger.info(`  Check Update: ${config.checkUpdate}`);

--- a/ui/app/pages/StatusPage.vue
+++ b/ui/app/pages/StatusPage.vue
@@ -562,6 +562,34 @@
                                         stroke-linejoin="round"
                                         style="margin-right: 6px; vertical-align: middle"
                                     >
+                                        <polyline points="16 18 22 12 16 6"></polyline>
+                                        <polyline points="8 6 2 12 8 18"></polyline>
+                                    </svg>
+                                    <span>
+                                        {{ t("forceCodeExecution") }}
+                                        <EnvVarTooltip env-var="FORCE_CODE_EXECUTION" doc-section="other-config" />
+                                    </span>
+                                </span>
+                                <span
+                                    class="value status-text-bold"
+                                    :class="state.forceCodeExecutionEnabled ? 'status-ok' : 'status-error'"
+                                    >{{ state.forceCodeExecutionEnabled ? t("enabled") : t("disabled") }}</span
+                                >
+                            </div>
+                            <div class="status-item">
+                                <span class="label">
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        width="14"
+                                        height="14"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        stroke-width="2"
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        style="margin-right: 6px; vertical-align: middle"
+                                    >
                                         <path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path>
                                         <path d="M21 3v5h-5"></path>
                                     </svg>
@@ -1492,6 +1520,31 @@
                                     v-model="state.forceUrlContextEnabled"
                                     :width="50"
                                     :before-change="handleForceUrlContextBeforeChange"
+                                />
+                            </div>
+                            <div class="switch-container">
+                                <span class="label">
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        width="14"
+                                        height="14"
+                                        viewBox="0 0 24 24"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        stroke-width="2"
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        style="margin-right: 6px; vertical-align: middle"
+                                    >
+                                        <polyline points="16 18 22 12 16 6"></polyline>
+                                        <polyline points="8 6 2 12 8 18"></polyline>
+                                    </svg>
+                                    {{ t("forceCodeExecution") }}
+                                </span>
+                                <el-switch
+                                    v-model="state.forceCodeExecutionEnabled"
+                                    :width="50"
+                                    :before-change="handleForceCodeExecutionBeforeChange"
                                 />
                             </div>
                             <div class="switch-container">
@@ -3654,6 +3707,7 @@ const state = reactive({
     enableAuthUpdateEnabled: true,
     failureCount: 0,
     floatingActionsExpanded: false,
+    forceCodeExecutionEnabled: false,
     forceThinkingEnabled: false,
     forceUrlContextEnabled: false,
     forceWebSearchEnabled: false,
@@ -4141,6 +4195,9 @@ const handleForceThinkingBeforeChange = () => handleSettingChange("/api/settings
 const handleForceUrlContextBeforeChange = () =>
     handleSettingChange("/api/settings/force-url-context", "forceUrlContext");
 
+const handleForceCodeExecutionBeforeChange = () =>
+    handleSettingChange("/api/settings/force-code-execution", "forceCodeExecution");
+
 const handleForceWebSearchBeforeChange = () => handleSettingChange("/api/settings/force-web-search", "forceWebSearch");
 const handleCheckUpdateBeforeChange = () => handleSettingChange("/api/settings/check-update", "checkUpdate");
 const handleEnableAuthUpdateBeforeChange = () =>
@@ -4382,6 +4439,7 @@ const updateStatus = data => {
     state.streamingModeReal = data.status.streamingMode === "real";
     state.enableAuthUpdateEnabled = isEnabled(data.status.enableAuthUpdate);
     state.forceThinkingEnabled = isEnabled(data.status.forceThinking);
+    state.forceCodeExecutionEnabled = isEnabled(data.status.forceCodeExecution);
     state.forceWebSearchEnabled = isEnabled(data.status.forceWebSearch);
     state.forceUrlContextEnabled = isEnabled(data.status.forceUrlContext);
     state.debugModeEnabled = isEnabled(data.status.debugMode);

--- a/ui/locales/en.json
+++ b/ui/locales/en.json
@@ -138,6 +138,7 @@
     "fileUploadFailed": "Upload failed: {error}",
     "fileUploadSuccess": "Upload successful",
     "followSystem": "Follow System",
+    "forceCodeExecution": "Force Code Execution",
     "forceThinking": "Force Thinking",
     "forceUrlContext": "Force URL Context",
     "forceWebSearch": "Force Web Search",

--- a/ui/locales/zh.json
+++ b/ui/locales/zh.json
@@ -138,6 +138,7 @@
     "fileUploadFailed": "上传失败：{error}",
     "fileUploadSuccess": "上传成功",
     "followSystem": "跟随系统",
+    "forceCodeExecution": "强制代码执行",
     "forceThinking": "强制思考",
     "forceUrlContext": "强制网址上下文",
     "forceWebSearch": "强制联网",


### PR DESCRIPTION
- fix #205

## 中文说明

### 功能概览

本 PR 新增了“代码执行 / Code Execution”的强制启用能力，并让它和现有的联网搜索、URL 上下文保持一致的使用体验。用户可以通过环境变量、Web UI 开关，或模型名后缀来为请求启用 Gemini 的代码执行能力。

### 如何使用

1. 通过环境变量全局开启：

```env
FORCE_CODE_EXECUTION=true
```

开启后，所有请求都会默认附带代码执行能力。

2. 通过模型名后缀按请求开启：

```text
gemini-3-flash-preview-code
gemini-3-flash-preview-real-code
gemini-3-flash-preview-minimal-search-code
gemini-3-flash-preview(minimal)-fake-search-code
```

其中：

- `-code` 表示强制开启代码执行。
- `-search` 表示强制开启联网搜索。
- 多个内置工具后缀可以组合使用，并放在模型名最后。
- 组合顺序建议为：思考级别 -> 流式模式 -> 内置工具，例如 `minimal-real-search-code` 这种语义顺序。

3. 通过 Web UI 开启：

在状态 / 设置页面新增了“强制代码执行”开关，可以直接在 UI 上启用或关闭，不需要手动修改环境变量。

### UI 变化

- 状态页面新增“强制代码执行”状态展示。
- 设置区域新增“强制代码执行”开关。
- 新增 `FORCE_CODE_EXECUTION` 的环境变量提示。
- 中英文界面均新增对应文案。

### 接口行为

- Gemini 原生请求支持强制附加 `codeExecution`。
- OpenAI Responses API 中的官方 `code_interpreter` 工具会映射到 Gemini 代码执行能力。
- Claude 格式请求中的 `code_execution` 工具会映射到 Gemini 代码执行能力。
- Claude 的 `web_search_*` 和 `web_fetch_*` 工具版本号不再固定，未来同类版本也能识别。
- 日志中模型后缀识别会合并展示内置工具开关，避免同一个模型名输出多条重复日志。

## English

### Overview

This PR adds force-enable support for Code Execution and aligns its behavior with the existing Web Search and URL Context options. Users can enable Gemini code execution through environment variables, the Web UI, or model name suffixes.

### How to Use

1. Enable globally with an environment variable:

```env
FORCE_CODE_EXECUTION=true
```

When enabled, all requests include code execution capability by default.

2. Enable per request with a model suffix:

```text
gemini-3-flash-preview-code
gemini-3-flash-preview-real-code
gemini-3-flash-preview-minimal-search-code
gemini-3-flash-preview(minimal)-fake-search-code
```

Notes:

- `-code` force-enables code execution.
- `-search` force-enables web search.
- Multiple built-in tool suffixes can be combined at the end of the model name.
- Recommended suffix order: thinking level -> streaming mode -> built-in tools.

3. Enable from the Web UI:

A new “Force Code Execution” switch is available on the status/settings page, so users can toggle it without editing environment variables manually.

### UI Changes

- Added Force Code Execution status display.
- Added Force Code Execution setting switch.
- Added `FORCE_CODE_EXECUTION` environment variable tooltip.
- Added both English and Chinese UI labels.

### API Behavior

- Native Gemini requests can be forced to include `codeExecution`.
- OpenAI Responses API `code_interpreter` tools are mapped to Gemini code execution.
- Claude-format `code_execution` tools are mapped to Gemini code execution.
- Claude `web_search_*` and `web_fetch_*` tool types now support versioned prefixes instead of a single fixed version.
- Model suffix logs now combine built-in tool flags into one message to avoid duplicated log lines for the same model.