### PR TITLE
fix: filter 2.5 image model request fields

### DIFF
--- a/scripts/client/build.js
+++ b/scripts/client/build.js
@@ -405,12 +405,13 @@ class RequestProcessor {
 
                     // --- Module 1: Embedding/TTS Model Filtering ---
                     const isImageModel = requestSpec.path.includes("-image") || requestSpec.path.includes("imagen");
+                    const isGemini25ImageModel = isImageModel && requestSpec.path.includes("2.5");
                     const isEmbeddingModel = requestSpec.path.includes("embedding");
                     const isTtsModel = requestSpec.path.includes("tts");
+                    const toolRelatedKeys = ["tools", "toolConfig", "tool_config", "toolChoice", "tool_choice"];
                     if (isEmbeddingModel || isTtsModel) {
                         // Remove tools
-                        const incompatibleKeys = ["toolConfig", "tool_config", "toolChoice", "tools"];
-                        incompatibleKeys.forEach(key => {
+                        toolRelatedKeys.forEach(key => {
                             if (Object.prototype.hasOwnProperty.call(bodyObj, key)) delete bodyObj[key];
                         });
                         // Remove thinkingConfig
@@ -420,10 +421,6 @@ class RequestProcessor {
                         // Remove systemInstruction
                         if (bodyObj.systemInstruction) {
                             delete bodyObj.systemInstruction;
-                        }
-                        // Remove response_mime_type
-                        if (bodyObj.generationConfig?.response_mime_type) {
-                            delete bodyObj.generationConfig.response_mime_type;
                         }
                         if (bodyObj.generationConfig?.responseMimeType) {
                             delete bodyObj.generationConfig.responseMimeType;
@@ -453,6 +450,14 @@ class RequestProcessor {
                     // --- Module 3: Robotics Model Filtering ---
                     const isComputerUseModel = requestSpec.path.includes("computer-use");
                     const isRoboticsModel = requestSpec.path.includes("robotics");
+                    if (isGemini25ImageModel) {
+                        toolRelatedKeys.forEach(key => {
+                            if (Object.prototype.hasOwnProperty.call(bodyObj, key)) delete bodyObj[key];
+                        });
+                        if (bodyObj.generationConfig?.thinkingConfig) {
+                            delete bodyObj.generationConfig.thinkingConfig;
+                        }
+                    }
                     if (isImageModel || isComputerUseModel || isRoboticsModel) {
                         if (bodyObj.generationConfig?.responseMimeType) {
                             delete bodyObj.generationConfig.responseMimeType;
@@ -471,14 +476,11 @@ class RequestProcessor {
                     // If model starts with gemini-2 and response format is JSON, remove tools/toolConfig
                     // This prevents 400 errors as some Gemini 2 variants don't support combined Tool + Structured Output
                     const isGemini2 = requestSpec.path.match(/\/models\/gemini-2/);
-                    const isJsonMode =
-                        bodyObj.generationConfig?.responseMimeType === "application/json" ||
-                        bodyObj.generationConfig?.response_mime_type === "application/json";
+                    const isJsonMode = bodyObj.generationConfig?.responseMimeType === "application/json";
 
                     if (isGemini2 && isJsonMode) {
-                        const incompatibleKeys = ["toolConfig", "tool_config", "toolChoice", "tools"];
                         let keysRemoved = 0;
-                        incompatibleKeys.forEach(key => {
+                        toolRelatedKeys.forEach(key => {
                             if (Object.prototype.hasOwnProperty.call(bodyObj, key)) {
                                 delete bodyObj[key];
                                 keysRemoved++;

--- a/src/core/BrowserManager.js
+++ b/src/core/BrowserManager.js
@@ -76,7 +76,7 @@ class BrowserManager {
         this._wsInitState = new Map();
 
         // Target URL for AI Studio app
-        this.targetUrl = "https://ai.studio/apps/7bfbb4ef-1e3b-4b46-a37f-37d79c771aa0";
+        this.targetUrl = "https://ai.studio/apps/b14eb99d-655e-4d29-ba95-218a8c086e07";
 
         // Firefox/Camoufox does not use Chromium-style command line args.
         // We keep this empty; Camoufox has its own anti-fingerprinting optimizations built-in.

--- a/src/core/BrowserManager.js
+++ b/src/core/BrowserManager.js
@@ -348,6 +348,7 @@ class BrowserManager {
         const startTime = Date.now();
         const checkInterval = 1000; // Check every 1 second
         let continueClicked = false;
+        let skipClicked = false;
         let iteration = 0;
 
         try {
@@ -378,6 +379,19 @@ class BrowserManager {
                     );
                     if (continueClicked) {
                         this.logger.info(`${logPrefix} Found "${continueText}" button, clicking...`);
+                    }
+                }
+
+                if (!skipClicked) {
+                    const skipText = "Skip";
+                    skipClicked = await this._clickButtonByTextIfVisible(
+                        page,
+                        skipText,
+                        logPrefix,
+                        `popup "${skipText}"`
+                    );
+                    if (skipClicked) {
+                        this.logger.info(`${logPrefix} Found "${skipText}" button, clicking...`);
                     }
                 }
 
@@ -1004,7 +1018,15 @@ class BrowserManager {
                             "div.cdk-global-overlay-wrapper",
                         ];
 
-                        const targetTexts = ["Reload", "Retry", "Got it", "Dismiss", "Not now", "Continue to the app"];
+                        const targetTexts = [
+                            "Reload",
+                            "Retry",
+                            "Got it",
+                            "Dismiss",
+                            "Not now",
+                            "Continue to the app",
+                            "Skip",
+                        ];
 
                         // Remove passive blockers
                         blockers.forEach(selector => {


### PR DESCRIPTION
中文：2.5 系列生图模型会在最后一层过滤 tools/toolConfig/tool_config/toolChoice/tool_choice 和 thinkingConfig，并继续移除 responseMimeType/responseJsonSchema。
English: 2.5 image models now filter tools/toolConfig/tool_config/toolChoice/tool_choice and thinkingConfig at the final request layer, while still removing responseMimeType/responseJsonSchema.
- fix #207