### PR TITLE
chore: add quick production restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@
    npm start
    ```
 
+   如果已经构建过前端资源，后续只想快速重启服务，可使用：
+
+   ```bash
+   npm run quick-start
+   ```
+
    API 服务将在 `http://localhost:7860` 上运行。
 
    服务启动后，您可以在浏览器中访问 `http://localhost:7860` 打开 Web 控制台主页，在这里可以查看账号状态和服务状态。
@@ -59,6 +65,7 @@
    ```bash
    git pull
    npm install
+   npm start
    ```
 
 > ⚠ **注意：** 直接运行不支持通过 VNC 在线添加账号，需要使用 `npm run setup-auth` 脚本添加账号。当前 VNC 登录功能仅在 Docker 容器中可用。

--- a/README_EN.md
+++ b/README_EN.md
@@ -49,6 +49,12 @@ A tool that wraps the Google AI Studio Build App web interface to provide OpenAI
    npm start
    ```
 
+   If the frontend assets have already been built and you only want to restart the service quickly, use:
+
+   ```bash
+   npm run quick-start
+   ```
+
    The API server will be available at `http://localhost:7860`
 
    After the service starts, you can access `http://localhost:7860` in your browser to open the web console homepage, where you can view account status and service status.
@@ -59,6 +65,7 @@ A tool that wraps the Google AI Studio Build App web interface to provide OpenAI
    ```bash
    git pull
    npm install
+   npm start
    ```
 
 > ⚠ **Note:** Running directly does not support adding accounts via VNC online. You need to use the `npm run setup-auth` script to add accounts. VNC login is only available in Docker deployments.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "build:ui": "vite build",
         "preview:ui": "vite preview",
         "start": "cross-env NODE_ENV=production node main.js",
+        "quick-start": "cross-env NODE_ENV=production node main.js",
         "prestart": "npm run build:ui",
         "save-auth": "node scripts/auth/saveAuth.js",
         "setup-auth": "node scripts/auth/setupAuth.js",


### PR DESCRIPTION
Adds `npm run quick-start` to quickly restart the production server after frontend assets have already been built.

新增 `npm run quick-start` 启动命令，用于在前端资源已构建后快速重启生产服务。

- fix #210 